### PR TITLE
Add material-specific flexo diagnostic

### DIFF
--- a/app.py
+++ b/app.py
@@ -1572,13 +1572,14 @@ def revision_flexo():
             archivo = request.files.get("archivo_revision")
             anilox_lpi = int(request.form.get("anilox_lpi", 360))
             paso_mm = int(request.form.get("paso_cilindro", 330))
+            material = request.form.get("material", "")
 
             if archivo and archivo.filename.endswith(".pdf"):
                 filename = secure_filename(archivo.filename)
                 path = os.path.join("uploads_flexo", filename)
                 archivo.save(path)
 
-                resultado_revision = revisar_diseño_flexo(path, anilox_lpi, paso_mm)
+                resultado_revision = revisar_diseño_flexo(path, anilox_lpi, paso_mm, material)
             else:
                 mensaje = "Archivo inválido. Subí un PDF."
         except Exception as e:

--- a/templates/revision_flexo.html
+++ b/templates/revision_flexo.html
@@ -103,6 +103,13 @@
       <label for="paso_cilindro">Paso del cilindro (mm):</label>
       <input type="number" name="paso_cilindro" value="330" required>
 
+      <label for="material">Material de impresión:</label>
+      <select name="material">
+        <option value="film">Film</option>
+        <option value="papel">Papel</option>
+        <option value="etiqueta adhesiva">Etiqueta adhesiva</option>
+      </select>
+
       <button type="submit">Revisar diseño</button>
     </form>
 


### PR DESCRIPTION
## Summary
- allow selecting printing material and propagate to diagnostic
- extend flexo analysis with material-dependent recommendations and HTML section
- expose material selector in flexo review form

## Testing
- `python -m py_compile montaje_flexo.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_688ee13cc21c83228b60dfe3a754f1e6