### PR TITLE
feat: add flexo ink transmission simulation

### DIFF
--- a/app.py
+++ b/app.py
@@ -1573,13 +1573,31 @@ def revision_flexo():
             anilox_lpi = int(request.form.get("anilox_lpi", 360))
             paso_mm = int(request.form.get("paso_cilindro", 330))
             material = request.form.get("material", "")
+            anilox_bcm = request.form.get("anilox_bcm")
+            velocidad = request.form.get("velocidad_impresion")
+            cobertura = request.form.get("cobertura_estimada")
+
+            if anilox_bcm and velocidad and cobertura:
+                anilox_bcm = float(anilox_bcm)
+                velocidad = float(velocidad)
+                cobertura = float(cobertura)
+            else:
+                anilox_bcm = velocidad = cobertura = None
 
             if archivo and archivo.filename.endswith(".pdf"):
                 filename = secure_filename(archivo.filename)
                 path = os.path.join("uploads_flexo", filename)
                 archivo.save(path)
 
-                resultado_revision = revisar_diseño_flexo(path, anilox_lpi, paso_mm, material)
+                resultado_revision = revisar_diseño_flexo(
+                    path,
+                    anilox_lpi,
+                    paso_mm,
+                    material,
+                    anilox_bcm,
+                    velocidad,
+                    cobertura,
+                )
             else:
                 mensaje = "Archivo inválido. Subí un PDF."
         except Exception as e:

--- a/templates/revision_flexo.html
+++ b/templates/revision_flexo.html
@@ -100,6 +100,9 @@
       <label for="anilox_lpi">Lineatura del Anilox (lpi):</label>
       <input type="number" name="anilox_lpi" value="360" required>
 
+      <label for="anilox_bcm">BCM del anilox (cm³/m²):</label>
+      <input type="number" step="0.01" name="anilox_bcm" placeholder="3.5">
+
       <label for="paso_cilindro">Paso del cilindro (mm):</label>
       <input type="number" name="paso_cilindro" value="330" required>
 
@@ -109,6 +112,12 @@
         <option value="papel">Papel</option>
         <option value="etiqueta adhesiva">Etiqueta adhesiva</option>
       </select>
+
+      <label for="velocidad_impresion">Velocidad de impresión estimada (m/min):</label>
+      <input type="number" step="0.1" name="velocidad_impresion" placeholder="100">
+
+      <label for="cobertura_estimada">Cobertura estimada del diseño (%):</label>
+      <input type="number" name="cobertura_estimada" min="0" max="100" placeholder="60">
 
       <button type="submit">Revisar diseño</button>
     </form>


### PR DESCRIPTION
## Summary
- add user inputs for anilox BCM, print speed, and design coverage
- wire ink transfer simulation through revision endpoint
- calculate estimated ink transfer with material factors and warnings

## Testing
- `python -m py_compile montaje_flexo.py app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ef18ea10c8322b4158c8c5c56fc4e