### PR TITLE
Añade gráfico de tinta en diagnóstico flexográfico

### DIFF
--- a/app.py
+++ b/app.py
@@ -1566,6 +1566,7 @@ def revision_flexo():
     from montaje_flexo import revisar_diseño_flexo
     mensaje = ""
     resultado_revision = ""
+    grafico_tinta = ""
 
     if request.method == "POST":
         try:
@@ -1589,7 +1590,7 @@ def revision_flexo():
                 path = os.path.join("uploads_flexo", filename)
                 archivo.save(path)
 
-                resultado_revision = revisar_diseño_flexo(
+                resultado_revision, grafico_tinta = revisar_diseño_flexo(
                     path,
                     anilox_lpi,
                     paso_mm,
@@ -1603,7 +1604,12 @@ def revision_flexo():
         except Exception as e:
             mensaje = f"Error al revisar diseño: {str(e)}"
 
-    return render_template("revision_flexo.html", mensaje=mensaje, resultado_revision=resultado_revision)
+    return render_template(
+        "revision_flexo.html",
+        mensaje=mensaje,
+        resultado_revision=resultado_revision,
+        grafico_tinta=grafico_tinta,
+    )
 
 
 

--- a/templates/revision_flexo.html
+++ b/templates/revision_flexo.html
@@ -128,6 +128,11 @@
 
     {% if resultado_revision %}
       <div class="resultado">{{ resultado_revision | safe }}</div>
+      {% if grafico_tinta %}
+        <div class="resultado" style="text-align:center;">
+          <img src="data:image/png;base64,{{ grafico_tinta }}" alt="Gráfico de tinta"/>
+        </div>
+      {% endif %}
     {% endif %}
   </div>
 </body>


### PR DESCRIPTION
## Summary
- Genera gráficos de barras en memoria para comparar tinta estimada vs ideal.
- Integra el gráfico en el diagnóstico de `revisar_diseño_flexo` y expone imagen base64.
- Actualiza la ruta Flask y la plantilla para mostrar el gráfico junto al diagnóstico.

## Testing
- `python -m py_compile montaje_flexo.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_688ef84f60088322a55b37e96b7a62c7