### PR TITLE
Add AI-based suggestions to flexographic diagnosis

### DIFF
--- a/montaje_flexo.py
+++ b/montaje_flexo.py
@@ -10,6 +10,7 @@ import re
 import matplotlib.pyplot as plt
 from io import BytesIO
 import base64
+from html import unescape
 
 
 def convertir_pts_a_mm(valor_pts):
@@ -512,4 +513,13 @@ def revisar_diseño_flexo(
   {seccion_tinta}
 </div>
 """
-    return resumen, imagen_tinta
+    diagnostico_texto = generar_diagnostico_texto(resumen)
+    return resumen, imagen_tinta, diagnostico_texto
+
+
+def generar_diagnostico_texto(html_diagnostico: str) -> str:
+    """Convierte el diagnóstico en HTML a un texto plano legible."""
+    texto = re.sub(r"<[^>]+>", "", html_diagnostico)
+    texto = unescape(texto)
+    lineas = [line.strip() for line in texto.splitlines() if line.strip()]
+    return "\n".join(lineas)

--- a/templates/revision_flexo.html
+++ b/templates/revision_flexo.html
@@ -133,6 +133,19 @@
           <img src="data:image/png;base64,{{ grafico_tinta }}" alt="Gráfico de tinta"/>
         </div>
       {% endif %}
+      <form action="/sugerencia_ia" method="POST">
+        <input type="hidden" name="diagnostico_texto_b64" value="{{ diagnostico_texto_b64 }}">
+        <input type="hidden" name="resultado_revision_b64" value="{{ resultado_revision_b64 }}">
+        <input type="hidden" name="grafico_tinta" value="{{ grafico_tinta }}">
+        <button type="submit">🧠 Obtener sugerencia IA</button>
+      </form>
+    {% endif %}
+
+    {% if sugerencia_ia %}
+      <div class="resultado">
+        <h2>🔍 Sugerencia de IA</h2>
+        <pre>{{ sugerencia_ia }}</pre>
+      </div>
     {% endif %}
   </div>
 </body>


### PR DESCRIPTION
## Summary
- add button to request AI suggestions after flexographic diagnosis
- introduce `/sugerencia_ia` route using OpenAI GPT-4 to generate technical recommendations
- expose plain text diagnostic data for AI via `generar_diagnostico_texto`

## Testing
- `python -m py_compile app.py montaje_flexo.py`


------
https://chatgpt.com/codex/tasks/task_e_688f087a532083229f7631dacda1726c