### PR TITLE
Add production suggestion AI endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -1666,6 +1666,34 @@ def sugerencia_ia():
     )
 
 
+@app.route("/sugerencia_produccion", methods=["POST"])
+def sugerencia_produccion():
+    from montaje_flexo import generar_sugerencia_produccion
+
+    resultado_revision_b64 = request.form.get("resultado_revision_b64", "")
+    diagnostico_texto_b64 = request.form.get("diagnostico_texto_b64", "")
+    grafico_tinta = request.form.get("grafico_tinta", "")
+
+    try:
+        resultado_revision = base64.b64decode(resultado_revision_b64).decode("utf-8")
+        diagnostico_texto = base64.b64decode(diagnostico_texto_b64).decode("utf-8")
+    except Exception:
+        resultado_revision = ""
+        diagnostico_texto = ""
+
+    sugerencia = generar_sugerencia_produccion(diagnostico_texto, resultado_revision)
+
+    return render_template(
+        "revision_flexo.html",
+        resultado_revision=resultado_revision,
+        grafico_tinta=grafico_tinta,
+        diagnostico_texto=diagnostico_texto,
+        diagnostico_texto_b64=diagnostico_texto_b64,
+        resultado_revision_b64=resultado_revision_b64,
+        sugerencia_produccion=sugerencia,
+    )
+
+
 
 
 if __name__ == '__main__':

--- a/montaje_flexo.py
+++ b/montaje_flexo.py
@@ -11,6 +11,7 @@ import matplotlib.pyplot as plt
 from io import BytesIO
 import base64
 from html import unescape
+import openai
 
 
 def convertir_pts_a_mm(valor_pts):
@@ -523,3 +524,31 @@ def generar_diagnostico_texto(html_diagnostico: str) -> str:
     texto = unescape(texto)
     lineas = [line.strip() for line in texto.splitlines() if line.strip()]
     return "\n".join(lineas)
+
+
+def generar_sugerencia_produccion(diagnostico_texto: str, resultado_revision: str) -> str:
+    """Genera sugerencias prácticas de producción basadas en el diagnóstico."""
+    try:
+        mensajes = [
+            {
+                "role": "system",
+                "content": (
+                    "Eres un especialista en producción de impresión flexográfica. "
+                    "Brinda recomendaciones prácticas basadas en el diagnóstico entregado. "
+                    "Evalúa si el archivo está listo para impresión, riesgos en máquina, tipo de anilox según cobertura, "
+                    "cambios de técnica de impresión, uso de barniz, doble pasada o reducción de colores y ajustes de preprensa."
+                ),
+            },
+            {
+                "role": "user",
+                "content": f"Diagnóstico:\n{diagnostico_texto}\n\nResultado de la revisión:\n{resultado_revision}",
+            },
+        ]
+        respuesta = openai.ChatCompletion.create(
+            model="gpt-4",
+            messages=mensajes,
+            temperature=0.3,
+        )
+        return respuesta["choices"][0]["message"]["content"].strip()
+    except Exception as e:
+        return f"Error al obtener sugerencia de producción: {str(e)}"

--- a/templates/revision_flexo.html
+++ b/templates/revision_flexo.html
@@ -146,12 +146,25 @@
         <input type="hidden" name="grafico_tinta" value="{{ grafico_tinta }}">
         <button type="submit">🧠 Obtener sugerencia IA</button>
       </form>
+      <form action="/sugerencia_produccion" method="POST">
+        <input type="hidden" name="diagnostico_texto_b64" value="{{ diagnostico_texto_b64 }}">
+        <input type="hidden" name="resultado_revision_b64" value="{{ resultado_revision_b64 }}">
+        <input type="hidden" name="grafico_tinta" value="{{ grafico_tinta }}">
+        <button type="submit">🏭 Sugerencia de producción IA</button>
+      </form>
     {% endif %}
 
     {% if sugerencia_ia %}
       <div class="resultado">
         <h2>🔍 Sugerencia de IA</h2>
         <pre>{{ sugerencia_ia }}</pre>
+      </div>
+    {% endif %}
+
+    {% if sugerencia_produccion %}
+      <div class="resultado">
+        <h2>🏭 Sugerencia de producción IA</h2>
+        <pre>{{ sugerencia_produccion }}</pre>
       </div>
     {% endif %}
   </div>


### PR DESCRIPTION
## Summary
- add `generar_sugerencia_produccion` using OpenAI to provide practical production guidance
- expose `/sugerencia_produccion` endpoint and wire template button to call it
- render production AI suggestions beneath diagnostics in flexo review page

## Testing
- `python -m py_compile app.py montaje_flexo.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890e1d4c84083228875775915e19a0e