### PR TITLE
Refactor Flask app for modular routes and modern OpenAI client

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,9 +1,10 @@
 import os
 from flask import Flask
 
-app = Flask(__name__)
+from routes import routes_bp
 
-import routes  # noqa: E402, F401
+app = Flask(__name__)
+app.register_blueprint(routes_bp)
 
 if __name__ == "__main__":
     port = int(os.environ.get("PORT", 5000))

--- a/montaje_flexo.py
+++ b/montaje_flexo.py
@@ -11,7 +11,9 @@ import matplotlib.pyplot as plt
 from io import BytesIO
 import base64
 from html import unescape
-import openai
+from openai import OpenAI
+
+client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
 
 
 def convertir_pts_a_mm(valor_pts):
@@ -544,11 +546,11 @@ def generar_sugerencia_produccion(diagnostico_texto: str, resultado_revision: st
                 "content": f"Diagnóstico:\n{diagnostico_texto}\n\nResultado de la revisión:\n{resultado_revision}",
             },
         ]
-        respuesta = openai.ChatCompletion.create(
+        respuesta = client.chat.completions.create(
             model="gpt-4",
             messages=mensajes,
             temperature=0.3,
         )
-        return respuesta["choices"][0]["message"]["content"].strip()
+        return respuesta.choices[0].message.content.strip()
     except Exception as e:
         return f"Error al obtener sugerencia de producción: {str(e)}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,9 +3,9 @@ reportlab==4.1.0
 Pillow==10.4.0
 PyMuPDF==1.26.1
 gunicorn==21.2.0
-openai==0.28.1
+openai>=1.3.5
 numpy==1.26.4
-opencv-python==4.9.0.80
+opencv-python-headless==4.9.0.80
 matplotlib==3.8.4
 pdf2image==1.16.3
 PyPDF2==3.0.1

--- a/simulacion.py
+++ b/simulacion.py
@@ -29,18 +29,26 @@ def generar_preview_interactivo(input_path, output_folder="preview_temp"):
         pix.save(img_path)
         imagenes[i] = img_path
 
-    vista = f"""
-<!DOCTYPE html>
+    hojas_js = str(
+        [
+            [
+                [f"/preview_temp/pag_{i}.jpg" for i in frente],
+                [f"/preview_temp/pag_{i}.jpg" for i in dorso],
+            ]
+            for frente, dorso in hojas
+        ]
+    )
+    vista = """<!DOCTYPE html>
 <html lang='es'>
 <head>
 <meta charset='UTF-8'>
 <title>Vista previa del montaje</title>
 <style>
-body {{font-family:'Poppins',sans-serif;background:#f4f4f4;text-align:center;margin:0;padding:40px;}}
-.hoja {{display:flex;justify-content:center;gap:30px;margin:30px auto;}}
-.pagina {{background:#fff;box-shadow:0 0 15px rgba(0,0,0,0.2);padding:10px;border-radius:12px;}}
-.pagina img {{width:300px;border-radius:8px;}}
-button {{margin:8px;padding:12px 24px;font-size:16px;border:none;border-radius:8px;cursor:pointer;background-color:#007bff;color:white;}}
+body {font-family:'Poppins',sans-serif;background:#f4f4f4;text-align:center;margin:0;padding:40px;}
+.hoja {display:flex;justify-content:center;gap:30px;margin:30px auto;}
+.pagina {background:#fff;box-shadow:0 0 15px rgba(0,0,0,0.2);padding:10px;border-radius:12px;}
+.pagina img {width:300px;border-radius:8px;}
+button {margin:8px;padding:12px 24px;font-size:16px;border:none;border-radius:8px;cursor:pointer;background-color:#007bff;color:white;}
 </style>
 </head>
 <body>
@@ -57,7 +65,7 @@ button {{margin:8px;padding:12px 24px;font-size:16px;border:none;border-radius:8
   <button type='submit'>🖨️ Montar PDF final</button>
 </form>
 <script>
-const hojas = {str([[[f"/preview_temp/pag_{i}.jpg" for i in frente],[f"/preview_temp/pag_{i}.jpg" for i in dorso]] for frente,dorso in hojas])};
+const hojas = __HOJAS__;
 let indice = 0;
 function cargar(){
   document.getElementById('nro').innerText = indice + 1;
@@ -76,8 +84,8 @@ function anterior(){if(indice>0){indice--;cargar();}}
 cargar();
 </script>
 </body>
-</html>
-"""
+</html>"""
+    vista = vista.replace("__HOJAS__", hojas_js)
     with open(os.path.join(output_folder, "preview.html"), "w", encoding="utf-8") as f:
         f.write(vista)
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -246,7 +246,7 @@ button[value="analisis_grafico"]:hover {
     {% endif %}
 
     {% if output_pdf %}
-      <a href="{{ url_for('descargar_pdf') }}" class="descargar-link"> Descargar PDF Procesado</a>
+      <a href="{{ url_for('routes.descargar_pdf') }}" class="descargar-link"> Descargar PDF Procesado</a>
     {% endif %}
 
     {% if diagnostico %}


### PR DESCRIPTION
## Summary
- Register `routes.py` as a Flask Blueprint and link it in `app.py` to keep a single entry point.
- Upgrade to the new OpenAI client and use it across modules while switching to `opencv-python-headless` to avoid `libGL` issues.
- Rework the interactive preview generator to avoid f-string brace conflicts and adjust template links for the new blueprint.

## Testing
- `pip install -r requirements.txt`
- `OPENAI_API_KEY=dummy python -m py_compile app.py diagnostico.py ia_sugerencias.py montaje.py simulacion.py utils.py routes.py montaje_flexo.py`
- `OPENAI_API_KEY=dummy python app.py & sleep 2; kill $!`

------
https://chatgpt.com/codex/tasks/task_e_689152a935ac83228e00ef78b0cd96fd