### PR TITLE
Add efficiency metrics to flexo advanced montage

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -206,7 +206,15 @@ def montaje_flexo_avanzado():
     if etiquetas_por_repeticion <= 0:
         return "Las dimensiones no permiten ninguna etiqueta", 400
     repeticiones = math.ceil(cantidad / etiquetas_por_repeticion)
-    metros_totales = repeticiones * paso / 1000
+
+    # Cálculos de eficiencia y métricas adicionales
+    ancho_ocupado = pistas * ancho + max(pistas - 1, 0) * sep_h
+    espacio_desperdiciado = max(ancho_bobina - ancho_ocupado, 0)
+    uso_ancho = (ancho_ocupado / ancho_bobina * 100) if ancho_bobina > 0 else 0
+    etiquetas_por_metro = (
+        (1000 / paso) * etiquetas_por_repeticion if paso > 0 else 0
+    )
+    longitud_estimada = repeticiones * paso / 1000
 
     doc = fitz.open(path_pdf)
     label_pix = doc.load_page(0).get_pixmap()
@@ -230,10 +238,13 @@ def montaje_flexo_avanzado():
     with open(reporte_path, "w", encoding="utf-8") as f:
         f.write(
             f"""<html><body><h2>Reporte Montaje Flexo Avanzado</h2>
-            <p>Pistas: {pistas}</p>
-            <p>Etiquetas por repetición: {etiquetas_por_repeticion}</p>
-            <p>Repeticiones necesarias: {repeticiones}</p>
-            <p>Metros totales: {round(metros_totales, 2)} m</p>
+            <p><strong>Uso del ancho (%)</strong>: {uso_ancho:.2f}%</p>
+            <p><strong>Ancho ocupado (mm)</strong>: {ancho_ocupado:.2f}</p>
+            <p><strong>Espacio desperdiciado (mm)</strong>: {espacio_desperdiciado:.2f}</p>
+            <p><strong>Etiquetas por repetición</strong>: {etiquetas_por_repeticion}</p>
+            <p><strong>Repeticiones necesarias</strong>: {repeticiones}</p>
+            <p><strong>Etiquetas por metro</strong>: {etiquetas_por_metro:.2f}</p>
+            <p><strong>Longitud estimada (m)</strong>: {longitud_estimada:.2f}</p>
             </body></html>"""
         )
 
@@ -246,7 +257,12 @@ def montaje_flexo_avanzado():
         pistas=pistas,
         etiquetas_por_repeticion=etiquetas_por_repeticion,
         repeticiones=repeticiones,
-        metros_totales=round(metros_totales, 2),
+        metros_totales=round(longitud_estimada, 2),
+        uso_ancho=round(uso_ancho, 2),
+        ancho_ocupado=round(ancho_ocupado, 2),
+        espacio_desperdiciado=round(espacio_desperdiciado, 2),
+        etiquetas_por_metro=round(etiquetas_por_metro, 2),
+        longitud_estimada=round(longitud_estimada, 2),
     )
 
 

--- a/templates/montaje_flexo_avanzado.html
+++ b/templates/montaje_flexo_avanzado.html
@@ -138,7 +138,10 @@
     <div class="preview">
       <h3>Vista previa</h3>
       <img src="data:image/png;base64,{{preview}}" alt="Vista previa del montaje">
-      <p>Pistas: {{pistas}} | Etiquetas por repetición: {{etiquetas_por_repeticion}} | Repeticiones: {{repeticiones}} | Metros: {{metros_totales}} m</p>
+      <p>Pistas: {{pistas}}</p>
+      <p>Uso del ancho: {{uso_ancho}}% | Ancho ocupado: {{ancho_ocupado}} mm | Espacio desperdiciado: {{espacio_desperdiciado}} mm</p>
+      <p>Etiquetas por repetición: {{etiquetas_por_repeticion}} | Repeticiones necesarias: {{repeticiones}}</p>
+      <p>Etiquetas por metro: {{etiquetas_por_metro}} | Longitud estimada: {{longitud_estimada}} m</p>
       <div class="descargas">
         <a href="/descargar_montaje_flexo_avanzado">Descargar Montaje PDF</a>
         <a href="/descargar_reporte_flexo_avanzado" style="background:#28a745;">Descargar Reporte</a>


### PR DESCRIPTION
## Summary
- compute width usage efficiency, wasted width, labels per meter and estimated roll length in `montaje_flexo_avanzado`
- include new metrics in generated HTML report and template preview

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689223b8f9ec8322bf60e0b7f00f9a79