### PR TITLE
feat: add label alignment options

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -195,6 +195,7 @@ def montaje_flexo_avanzado():
         paso = float(request.form.get("paso", 0))
         sep_h = float(request.form.get("sep_h", 0))
         sep_v = float(request.form.get("sep_v", 0))
+        alignment = request.form.get("alignment", "center")
         cantidad = int(request.form.get("cantidad", 0))
         margen = float(request.form.get("margen_lateral", 0))
     except ValueError:
@@ -215,8 +216,20 @@ def montaje_flexo_avanzado():
 
     output_pdf_path = os.path.join(OUTPUT_FOLDER_FLEXO, "montaje_flexo_avanzado.pdf")
     c = canvas.Canvas(output_pdf_path, pagesize=(ancho_bobina * mm, paso * mm))
-    for i in range(pistas):
-        x = (margen + i * (ancho + sep_h)) * mm
+
+    total_row_width = pistas * ancho + (pistas - 1) * sep_h
+    if alignment == "left":
+        start_x = margen
+        x_positions = [start_x + i * (ancho + sep_h) for i in range(pistas)]
+    elif alignment == "right":
+        start_x = ancho_bobina - margen - ancho
+        x_positions = [start_x - i * (ancho + sep_h) for i in range(pistas)]
+    else:
+        start_x = (ancho_bobina - total_row_width) / 2
+        x_positions = [start_x + i * (ancho + sep_h) for i in range(pistas)]
+
+    for x_mm in x_positions:
+        x = x_mm * mm
         for j in range(filas):
             y = (paso - alto - j * (alto + sep_v)) * mm
             c.drawImage(label_img_path, x, y, ancho * mm, alto * mm)
@@ -234,6 +247,7 @@ def montaje_flexo_avanzado():
             <p>Etiquetas por repetición: {etiquetas_por_repeticion}</p>
             <p>Repeticiones necesarias: {repeticiones}</p>
             <p>Metros totales: {round(metros_totales, 2)} m</p>
+            <p>Alineación: {alignment}</p>
             </body></html>"""
         )
 
@@ -247,6 +261,7 @@ def montaje_flexo_avanzado():
         etiquetas_por_repeticion=etiquetas_por_repeticion,
         repeticiones=repeticiones,
         metros_totales=round(metros_totales, 2),
+        alignment=alignment,
     )
 
 

--- a/templates/montaje_flexo_avanzado.html
+++ b/templates/montaje_flexo_avanzado.html
@@ -124,6 +124,14 @@
         <input type="number" step="0.1" id="sep_v" name="sep_v" value="0" required>
       </div>
       <div>
+        <label for="alignment">Alignment</label>
+        <select id="alignment" name="alignment">
+          <option value="center">center</option>
+          <option value="left">left</option>
+          <option value="right">right</option>
+        </select>
+      </div>
+      <div>
         <label for="cantidad">Cantidad total de etiquetas</label>
         <input type="number" id="cantidad" name="cantidad" required>
       </div>
@@ -138,7 +146,7 @@
     <div class="preview">
       <h3>Vista previa</h3>
       <img src="data:image/png;base64,{{preview}}" alt="Vista previa del montaje">
-      <p>Pistas: {{pistas}} | Etiquetas por repetición: {{etiquetas_por_repeticion}} | Repeticiones: {{repeticiones}} | Metros: {{metros_totales}} m</p>
+      <p>Pistas: {{pistas}} | Etiquetas por repetición: {{etiquetas_por_repeticion}} | Repeticiones: {{repeticiones}} | Metros: {{metros_totales}} m | Alineación: {{alignment}}</p>
       <div class="descargas">
         <a href="/descargar_montaje_flexo_avanzado">Descargar Montaje PDF</a>
         <a href="/descargar_reporte_flexo_avanzado" style="background:#28a745;">Descargar Reporte</a>


### PR DESCRIPTION
## Summary
- allow selecting label alignment (center/left/right) in advanced flexo montage
- compute label positions according to alignment and include choice in report and preview

## Testing
- `python -m py_compile routes.py`
- `python -m py_compile montaje_flexo.py`


------
https://chatgpt.com/codex/tasks/task_e_689229ea5b0c8322a207e35b92371670