### PR TITLE
feat: auto fix bleed and crop marks

### DIFF
--- a/templates/montaje_flexo_avanzado.html
+++ b/templates/montaje_flexo_avanzado.html
@@ -99,6 +99,12 @@
         <label for="pdf">PDF del diseño</label>
         <input type="file" id="pdf" name="pdf" accept="application/pdf" required>
       </div>
+      <div class="full-width">
+        <label><input type="checkbox" name="auto_sangrado"> Agregar sangrado automático si no tiene</label>
+      </div>
+      <div class="full-width">
+        <label><input type="checkbox" name="auto_marcas"> Agregar marcas de corte si no tiene</label>
+      </div>
       <div>
         <label for="ancho_etiqueta">Ancho etiqueta (mm)</label>
         <input type="number" step="0.1" id="ancho_etiqueta" name="ancho_etiqueta" required>


### PR DESCRIPTION
## Summary
- add `corregir_sangrado_y_marcas` to expand PDFs lacking bleed and crop marks
- expose checkboxes in advanced flexo template to trigger automatic fixes
- run correction in routes and note auto-fix in generated report

## Testing
- `python -m py_compile montaje_flexo.py routes.py`


------
https://chatgpt.com/codex/tasks/task_e_68923401d6e08322b9f8430ce4a3031a