### PR TITLE
Automate flexo label alignment based on leftover width

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -208,7 +208,7 @@ def montaje_flexo_avanzado():
         paso = float(request.form.get("paso", 0))
         sep_h = float(request.form.get("sep_h", 0))
         sep_v = float(request.form.get("sep_v", 0))
-        alignment = request.form.get("alignment", "center")
+        # La alineación se determinará automáticamente más adelante
         cantidad = int(request.form.get("cantidad", 0))
         margen = float(request.form.get("margen_lateral", 0))
     except ValueError:
@@ -231,15 +231,18 @@ def montaje_flexo_avanzado():
     c = canvas.Canvas(output_pdf_path, pagesize=(ancho_bobina * mm, paso * mm))
 
     total_row_width = pistas * ancho + (pistas - 1) * sep_h
-    if alignment == "left":
-        start_x = margen
-        x_positions = [start_x + i * (ancho + sep_h) for i in range(pistas)]
-    elif alignment == "right":
-        start_x = ancho_bobina - margen - ancho
-        x_positions = [start_x - i * (ancho + sep_h) for i in range(pistas)]
+
+    ancho_util = ancho_bobina - 2 * margen
+    espacio_sobrante = max(0, ancho_util - total_row_width)
+
+    if espacio_sobrante < 10:
+        alignment = "center"
+        start_x = margen + espacio_sobrante / 2
     else:
-        start_x = (ancho_bobina - total_row_width) / 2
-        x_positions = [start_x + i * (ancho + sep_h) for i in range(pistas)]
+        alignment = "left"
+        start_x = margen
+
+    x_positions = [start_x + i * (ancho + sep_h) for i in range(pistas)]
 
     for x_mm in x_positions:
         x = x_mm * mm

--- a/templates/montaje_flexo_avanzado.html
+++ b/templates/montaje_flexo_avanzado.html
@@ -130,20 +130,15 @@
         <input type="number" step="0.1" id="sep_v" name="sep_v" value="0" required>
       </div>
       <div>
-        <label for="alignment">Alignment</label>
-        <select id="alignment" name="alignment">
-          <option value="center">center</option>
-          <option value="left">left</option>
-          <option value="right">right</option>
-        </select>
-      </div>
-      <div>
         <label for="cantidad">Cantidad total de etiquetas</label>
         <input type="number" id="cantidad" name="cantidad" required>
       </div>
       <div>
         <label for="margen_lateral">Margen lateral (mm)</label>
         <input type="number" step="0.1" id="margen_lateral" name="margen_lateral" value="0">
+      </div>
+      <div class="full-width" style="font-size:12px;color:#555;">
+        La alineación horizontal se calcula automáticamente según el espacio sobrante.
       </div>
       <button type="submit">Generar Montaje</button>
     </form>


### PR DESCRIPTION
## Summary
- Compute leftover width and auto-align labels center or left
- Remove manual alignment option from flexo advanced template and add note

## Testing
- `python -m py_compile routes.py`


------
https://chatgpt.com/codex/tasks/task_e_68925c2cced08322b3afed2339b28612