### PR TITLE
Refactor label row calculation

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -17,7 +17,11 @@ from flask import (
 from werkzeug.utils import secure_filename
 from montaje import montar_pdf
 from diagnostico import diagnosticar_pdf, analizar_grafico_tecnico
-from utils import corregir_sangrado, redimensionar_pdf
+from utils import (
+    corregir_sangrado,
+    redimensionar_pdf,
+    calcular_etiquetas_por_fila,
+)
 from simulacion import generar_preview_interactivo, generar_preview_virtual
 from ia_sugerencias import chat_completion, transcribir_audio
 from montaje_flexo import (
@@ -221,8 +225,11 @@ def montaje_flexo_avanzado():
     if espacio_disponible <= 0:
         return "Las dimensiones no permiten ninguna etiqueta", 400
 
-    cantidad_pistas = int(
-        (espacio_disponible + sep_h) / (ancho_total_etiqueta + sep_h)
+    cantidad_pistas = calcular_etiquetas_por_fila(
+        ancho_bobina=ancho_bobina,
+        ancho_etiqueta=ancho_total_etiqueta,
+        separacion_horizontal=sep_h,
+        margen_lateral=margen,
     )
     cantidad_pistas = max(1, cantidad_pistas)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,12 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from utils import calcular_etiquetas_por_fila
+
+def test_calcular_etiquetas_por_fila_example():
+    assert calcular_etiquetas_por_fila(330, 100, 3, 0) == 3
+
+def test_calcular_etiquetas_por_fila_margin():
+    assert calcular_etiquetas_por_fila(330, 100, 3, 50) == 2

--- a/utils.py
+++ b/utils.py
@@ -77,3 +77,26 @@ def redimensionar_pdf(input_path, output_path, nuevo_ancho_mm, nuevo_alto_mm=Non
         )
 
     nuevo_doc.save(output_path)
+
+
+def calcular_etiquetas_por_fila(
+    ancho_bobina: float,
+    ancho_etiqueta: float,
+    separacion_horizontal: float = 0,
+    margen_lateral: float = 0,
+) -> int:
+    """Calcula cuántas etiquetas caben en una fila de la bobina.
+
+    Se resta el margen lateral de ambos lados del ancho total y se considera la
+    separación horizontal entre etiquetas para obtener el número máximo de
+    etiquetas completas que pueden colocarse.
+    """
+
+    ancho_disponible = ancho_bobina - (2 * margen_lateral)
+    if ancho_disponible <= 0:
+        return 0
+
+    return int(
+        (ancho_disponible + separacion_horizontal)
+        // (ancho_etiqueta + separacion_horizontal)
+    )


### PR DESCRIPTION
## Summary
- extract labels-per-row math into `calcular_etiquetas_por_fila`
- reuse helper in route for flexographic montage
- add tests validating margins and spacing behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68926bd10c2c8322a7902c6fb35c5290