### PR TITLE
fix: correct label count formula

### DIFF
--- a/montaje_flexo.py
+++ b/montaje_flexo.py
@@ -12,8 +12,37 @@ from io import BytesIO
 import base64
 from html import unescape
 from openai import OpenAI
+import math
 
 client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
+
+
+def calcular_etiquetas_por_fila(
+    ancho_bobina: float,
+    ancho_etiqueta: float,
+    separacion_horizontal: float = 0,
+    margen_lateral: float = 0,
+) -> int:
+    """Calcula el número de etiquetas que caben horizontalmente en la bobina.
+
+    La fórmula considera el ancho utilizable de la bobina restando los márgenes
+    laterales y aplica la separación horizontal entre etiquetas. Se usa
+    ``math.floor`` para asegurar que el resultado sea siempre un número entero
+    correcto, incluso con valores decimales.
+
+    Formula:
+    ``floor((ancho_bobina - (2 * margen_lateral) + separacion_horizontal) /
+    (ancho_etiqueta + separacion_horizontal))``
+    """
+
+    ancho_disponible = ancho_bobina - (2 * margen_lateral)
+    if ancho_disponible <= 0 or (ancho_etiqueta + separacion_horizontal) <= 0:
+        return 0
+
+    return math.floor(
+        (ancho_disponible + separacion_horizontal)
+        / (ancho_etiqueta + separacion_horizontal)
+    )
 
 
 def corregir_sangrado_y_marcas(pdf_path: str) -> str:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,3 +10,9 @@ def test_calcular_etiquetas_por_fila_example():
 
 def test_calcular_etiquetas_por_fila_margin():
     assert calcular_etiquetas_por_fila(330, 100, 3, 50) == 2
+
+
+def test_calcular_etiquetas_por_fila_decimales():
+    """Funciona con tamaños y separaciones decimales."""
+    resultado = calcular_etiquetas_por_fila(500, 123.3, 2.5, 10)
+    assert resultado == 3

--- a/utils.py
+++ b/utils.py
@@ -2,6 +2,7 @@ import fitz  # PyMuPDF
 from PIL import Image
 import numpy as np
 from io import BytesIO
+import math
 
 
 def corregir_sangrado(input_path, output_path):
@@ -93,10 +94,10 @@ def calcular_etiquetas_por_fila(
     """
 
     ancho_disponible = ancho_bobina - (2 * margen_lateral)
-    if ancho_disponible <= 0:
+    if ancho_disponible <= 0 or (ancho_etiqueta + separacion_horizontal) <= 0:
         return 0
 
-    return int(
+    return math.floor(
         (ancho_disponible + separacion_horizontal)
-        // (ancho_etiqueta + separacion_horizontal)
+        / (ancho_etiqueta + separacion_horizontal)
     )


### PR DESCRIPTION
## Summary
- fix label placement calculation to respect margins and spacing via math.floor
- add tests covering decimal sizes for label fitting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892752a7e5c83229c28ef4d2e3d4017