### PR TITLE
Add intelligent offset layout for multiple PDFs

### DIFF
--- a/montaje_offset_inteligente.py
+++ b/montaje_offset_inteligente.py
@@ -1,0 +1,166 @@
+import io
+from typing import List, Dict, Tuple
+
+import fitz  # PyMuPDF
+from PIL import Image, ImageOps
+from reportlab.pdfgen import canvas
+from reportlab.lib.utils import ImageReader
+
+MM_TO_PT = 2.83465  # milímetros a puntos
+
+
+def mm_to_pt(valor: float) -> float:
+    return valor * MM_TO_PT
+
+
+def obtener_dimensiones_pdf(path: str) -> Tuple[float, float]:
+    """Devuelve ancho y alto del primer página de un PDF en milímetros."""
+    doc = fitz.open(path)
+    page = doc[0]
+    bbox = page.rect
+    ancho_mm = bbox.width * 25.4 / 72
+    alto_mm = bbox.height * 25.4 / 72
+    doc.close()
+    return round(ancho_mm, 2), round(alto_mm, 2)
+
+
+def _pdf_a_imagen_con_sangrado(path: str, sangrado_mm: float) -> ImageReader:
+    """Rasteriza un PDF y añade un borde de sangrado replicando los bordes."""
+    doc = fitz.open(path)
+    page = doc[0]
+    pix = page.get_pixmap(dpi=300, alpha=False)
+    img = Image.frombytes("RGB", [pix.width, pix.height], pix.samples)
+
+    sangrado_px = int((sangrado_mm / 25.4) * 300)
+    img_con_sangrado = ImageOps.expand(img, border=sangrado_px)
+
+    w, h = img.width, img.height
+    left = img.crop((0, 0, 1, h)).resize((sangrado_px, h))
+    img_con_sangrado.paste(left, (0, sangrado_px))
+    right = img.crop((w - 1, 0, w, h)).resize((sangrado_px, h))
+    img_con_sangrado.paste(right, (sangrado_px + w, sangrado_px))
+    top = img.crop((0, 0, w, 1)).resize((w, sangrado_px))
+    img_con_sangrado.paste(top, (sangrado_px, 0))
+    bottom = img.crop((0, h - 1, w, h)).resize((w, sangrado_px))
+    img_con_sangrado.paste(bottom, (sangrado_px, sangrado_px + h))
+    tl = img.crop((0, 0, 1, 1)).resize((sangrado_px, sangrado_px))
+    img_con_sangrado.paste(tl, (0, 0))
+    tr = img.crop((w - 1, 0, w, 1)).resize((sangrado_px, sangrado_px))
+    img_con_sangrado.paste(tr, (sangrado_px + w, 0))
+    bl = img.crop((0, h - 1, 1, h)).resize((sangrado_px, sangrado_px))
+    img_con_sangrado.paste(bl, (0, sangrado_px + h))
+    br = img.crop((w - 1, h - 1, w, h)).resize((sangrado_px, sangrado_px))
+    img_con_sangrado.paste(br, (sangrado_px + w, sangrado_px + h))
+
+    img_byte_arr = io.BytesIO()
+    img_con_sangrado.save(img_byte_arr, format="PNG")
+    img_byte_arr.seek(0)
+    doc.close()
+    return ImageReader(img_byte_arr)
+
+
+def calcular_posiciones(
+    disenos: List[Dict[str, float]],
+    ancho_pliego: float,
+    alto_pliego: float,
+    margen: float = 10,
+    espacio: float = 5,
+    sangrado: float = 0,
+) -> List[Dict[str, float]]:
+    """Calcula posiciones de cada diseño evitando solapamientos."""
+    posiciones: List[Dict[str, float]] = []
+    x_cursor, y_cursor = margen, margen
+    fila_max_altura = 0
+
+    for diseno in disenos:
+        ancho_total = diseno["ancho"] + 2 * sangrado
+        alto_total = diseno["alto"] + 2 * sangrado
+
+        if x_cursor + ancho_total > ancho_pliego - margen:
+            x_cursor = margen
+            y_cursor += fila_max_altura + espacio
+            fila_max_altura = 0
+
+        if y_cursor + alto_total > alto_pliego - margen:
+            break
+
+        posiciones.append(
+            {
+                "archivo": diseno["archivo"],
+                "x": x_cursor,
+                "y": y_cursor,
+                "ancho": diseno["ancho"],
+                "alto": diseno["alto"],
+            }
+        )
+
+        x_cursor += ancho_total + espacio
+        fila_max_altura = max(fila_max_altura, alto_total)
+
+    return posiciones
+
+
+def agregar_marcas_registro(c: canvas.Canvas, sheet_w_pt: float, sheet_h_pt: float) -> None:
+    mark_len = mm_to_pt(5)
+    offset = mm_to_pt(5)
+    x = sheet_w_pt / 2
+    c.setLineWidth(0.3)
+    for y in (offset, sheet_h_pt - offset):
+        c.line(x - mark_len, y, x + mark_len, y)
+        c.line(x, y - mark_len, x, y + mark_len)
+        c.circle(x, y, mm_to_pt(1), stroke=1, fill=0)
+
+
+def montar_pliego_offset_inteligente(
+    file_paths: List[str],
+    ancho_pliego: float,
+    alto_pliego: float,
+    margen: float = 10,
+    espacio: float = 5,
+    sangrado: float = 3,
+    output_path: str = "output/pliego_offset_inteligente.pdf",
+) -> str:
+    """Genera un PDF montado acomodando diseños de distintos tamaños."""
+    disenos: List[Dict[str, float]] = []
+    for path in file_paths:
+        ancho, alto = obtener_dimensiones_pdf(path)
+        disenos.append({"archivo": path, "ancho": ancho, "alto": alto})
+
+    disenos.sort(key=lambda d: d["ancho"] * d["alto"], reverse=True)
+    posiciones = calcular_posiciones(
+        disenos, ancho_pliego, alto_pliego, margen=margen, espacio=espacio, sangrado=sangrado
+    )
+
+    sheet_w_pt = mm_to_pt(ancho_pliego)
+    sheet_h_pt = mm_to_pt(alto_pliego)
+    c = canvas.Canvas(output_path, pagesize=(sheet_w_pt, sheet_h_pt))
+
+    for pos in posiciones:
+        img = _pdf_a_imagen_con_sangrado(pos["archivo"], sangrado)
+        total_w_pt = mm_to_pt(pos["ancho"] + 2 * sangrado)
+        total_h_pt = mm_to_pt(pos["alto"] + 2 * sangrado)
+        x_pt = mm_to_pt(pos["x"])
+        y_pt = mm_to_pt(pos["y"])
+        c.drawImage(img, x_pt, y_pt, width=total_w_pt, height=total_h_pt)
+
+        # Marcas de corte
+        left = x_pt + mm_to_pt(sangrado)
+        bottom = y_pt + mm_to_pt(sangrado)
+        right = left + mm_to_pt(pos["ancho"])
+        top = bottom + mm_to_pt(pos["alto"])
+        mark_len = mm_to_pt(3)
+        c.setLineWidth(0.3)
+        c.setStrokeColorRGB(1, 0, 0)
+        c.line(left - mark_len, bottom, left, bottom)
+        c.line(left, bottom - mark_len, left, bottom)
+        c.line(right, bottom - mark_len, right, bottom)
+        c.line(right, bottom, right + mark_len, bottom)
+        c.line(left - mark_len, top, left, top)
+        c.line(left, top, left, top + mark_len)
+        c.line(right, top, right + mark_len, top)
+        c.line(right, top, right, top + mark_len)
+        c.setStrokeColorRGB(0, 0, 0)
+
+    agregar_marcas_registro(c, sheet_w_pt, sheet_h_pt)
+    c.save()
+    return output_path

--- a/templates/montaje_offset_inteligente.html
+++ b/templates/montaje_offset_inteligente.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <title>Montaje Offset Inteligente</title>
+</head>
+<body>
+  <h1>Montaje Offset Inteligente</h1>
+  <form method="POST" enctype="multipart/form-data">
+    <label>Subir de 1 a 5 archivos PDF:</label>
+    <input type="file" name="archivos[]" accept=".pdf" multiple required>
+    <br><br>
+    <label>Seleccionar tamaño de pliego:</label>
+    <select name="pliego">
+      <option value="640x880">640x880 mm</option>
+      <option value="700x1000">700x1000 mm</option>
+      <option value="personalizado">Personalizado</option>
+    </select>
+    <div id="pliego-personalizado" style="display:none;">
+      <label>Ancho del pliego (mm):</label>
+      <input type="number" name="ancho_pliego_custom" step="0.01">
+      <label>Alto del pliego (mm):</label>
+      <input type="number" name="alto_pliego_custom" step="0.01">
+    </div>
+    <br>
+    <button type="submit">Generar Montaje</button>
+  </form>
+  <script>
+    document.querySelector('select[name="pliego"]').addEventListener('change', function() {
+      document.getElementById('pliego-personalizado').style.display =
+        this.value === 'personalizado' ? 'block' : 'none';
+    });
+  </script>
+</body>
+</html>

--- a/tests/test_montaje_offset_inteligente.py
+++ b/tests/test_montaje_offset_inteligente.py
@@ -1,0 +1,41 @@
+import tempfile
+from pathlib import Path
+
+from reportlab.pdfgen import canvas
+from reportlab.lib.units import mm
+
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from montaje_offset_inteligente import obtener_dimensiones_pdf, calcular_posiciones
+
+
+def test_obtener_dimensiones_pdf():
+    with tempfile.NamedTemporaryFile(suffix=".pdf") as tmp:
+        c = canvas.Canvas(tmp.name, pagesize=(100 * mm, 50 * mm))
+        c.drawString(10, 10, "test")
+        c.save()
+        ancho, alto = obtener_dimensiones_pdf(tmp.name)
+        assert round(ancho) == 100
+        assert round(alto) == 50
+
+
+def test_calcular_posiciones_no_overlap():
+    disenos = [
+        {"archivo": "a.pdf", "ancho": 100, "alto": 50},
+        {"archivo": "b.pdf", "ancho": 80, "alto": 40},
+    ]
+    posiciones = calcular_posiciones(disenos, 300, 200, margen=10, espacio=5, sangrado=0)
+    assert len(posiciones) == 2
+    a, b = posiciones
+    overlap = not (
+        a["x"] + a["ancho"] <= b["x"]
+        or b["x"] + b["ancho"] <= a["x"]
+        or a["y"] + a["alto"] <= b["y"]
+        or b["y"] + b["alto"] <= a["y"]
+    )
+    assert not overlap
+    for pos in posiciones:
+        assert pos["x"] >= 10 and pos["y"] >= 10
+        assert pos["x"] + pos["ancho"] <= 300 - 10
+        assert pos["y"] + pos["alto"] <= 200 - 10


### PR DESCRIPTION
## Summary
- add intelligent offset layout module to detect individual PDF sizes and compose mixed-sheet PDFs with bleed and marks
- expose new route and template for uploading up to five PDFs and selecting predefined or custom sheet sizes
- include tests for dimension detection and layout positioning

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689418e1b9fc8322b3be858c4c7666a9