### PR TITLE
Enable repetitions per PDF in intelligent offset montage

### DIFF
--- a/montaje_offset_inteligente.py
+++ b/montaje_offset_inteligente.py
@@ -149,7 +149,7 @@ def agregar_marcas_registro(c: canvas.Canvas, sheet_w_pt: float, sheet_h_pt: flo
 
 
 def montar_pliego_offset_inteligente(
-    file_paths: List[str],
+    diseños: List[Tuple[str, int]],
     ancho_pliego: float,
     alto_pliego: float,
     margen: float = 10,
@@ -159,9 +159,10 @@ def montar_pliego_offset_inteligente(
 ) -> str:
     """Genera un PDF montado acomodando diseños de distintos tamaños."""
     disenos: List[Dict[str, float]] = []
-    for path in file_paths:
+    for path, cantidad in diseños:
         ancho, alto = obtener_dimensiones_pdf(path)
-        disenos.append({"archivo": path, "ancho": ancho, "alto": alto})
+        for _ in range(cantidad):
+            disenos.append({"archivo": path, "ancho": ancho, "alto": alto})
 
     disenos.sort(key=lambda d: d["ancho"] * d["alto"], reverse=True)
     posiciones = calcular_posiciones(

--- a/routes.py
+++ b/routes.py
@@ -208,15 +208,17 @@ def montaje_offset_inteligente_view():
     else:
         return "Formato de pliego inválido", 400
 
-    file_paths = []
-    for f in archivos:
+    diseños = []
+    for i, f in enumerate(archivos):
         filename = secure_filename(f.filename)
         path = os.path.join(UPLOAD_FOLDER, filename)
         f.save(path)
-        file_paths.append(path)
+
+        repeticiones = int(request.form.get(f"repeticiones_{i}", 1))
+        diseños.append((path, repeticiones))
 
     output_path = os.path.join("output", "pliego_offset_inteligente.pdf")
-    montar_pliego_offset_inteligente(file_paths, ancho_pliego, alto_pliego, output_path=output_path)
+    montar_pliego_offset_inteligente(diseños, ancho_pliego, alto_pliego, output_path=output_path)
     return send_file(output_path, as_attachment=True)
 
 

--- a/templates/montaje_offset_inteligente.html
+++ b/templates/montaje_offset_inteligente.html
@@ -9,6 +9,25 @@
   <form method="POST" enctype="multipart/form-data">
     <label>Subir de 1 a 5 archivos PDF:</label>
     <input type="file" name="archivos[]" accept=".pdf" multiple required>
+    <div id="repeticiones-container"></div>
+    <script>
+      document
+        .querySelector('input[name="archivos[]"]')
+        .addEventListener('change', function (e) {
+          const container = document.getElementById('repeticiones-container');
+          container.innerHTML = '';
+          [...this.files].forEach((file, index) => {
+            const div = document.createElement('div');
+            div.innerHTML = `
+        <label>${file.name} - Cantidad de repeticiones:</label>
+        <input type="number" name="repeticiones_${index}" min="1" value="1" required>
+        <input type="hidden" name="nombre_archivo_${index}" value="${file.name}">
+        <br><br>
+      `;
+            container.appendChild(div);
+          });
+        });
+    </script>
     <br><br>
     <label>Seleccionar tamaño de pliego:</label>
     <select name="pliego">


### PR DESCRIPTION
## Summary
- Allow entering repetition count for each uploaded PDF in the intelligent offset montage form
- Pass repetition counts from the route and update montage function to duplicate designs accordingly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894236527b883228fd1b09d00ffc27e