### PR TITLE
feat: add grid alignment option

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -220,6 +220,8 @@ def montaje_offset_inteligente_view():
     ordenar_tamano = request.form.get("ordenar_tamano") == "on"
     alinear_filas = request.form.get("alinear_filas") == "on"
     centrar_montaje = request.form.get("centrar_montaje") == "on"
+    forzar_grilla = request.form.get("forzar_grilla") == "on"
+    debug_grilla = request.form.get("debug_grilla") == "on"
 
     output_path = os.path.join("output", "pliego_offset_inteligente.pdf")
     montar_pliego_offset_inteligente(
@@ -230,6 +232,8 @@ def montaje_offset_inteligente_view():
         ordenar_tamano=ordenar_tamano,
         alinear_filas=alinear_filas,
         centrar=centrar_montaje,
+        forzar_grilla=forzar_grilla,
+        debug_grilla=debug_grilla,
         output_path=output_path,
     )
     return send_file(output_path, as_attachment=True)

--- a/templates/montaje_offset_inteligente.html
+++ b/templates/montaje_offset_inteligente.html
@@ -47,7 +47,9 @@
     <br>
     <label><input type="checkbox" name="ordenar_tamano"> Ordenar por tamaño</label><br>
     <label><input type="checkbox" name="alinear_filas"> Alinear por filas</label><br>
-    <label><input type="checkbox" name="centrar_montaje"> Centrar montaje en pliego</label>
+    <label><input type="checkbox" name="centrar_montaje"> Centrar montaje en pliego</label><br>
+    <label><input type="checkbox" name="forzar_grilla"> Forzar grilla</label><br>
+    <label><input type="checkbox" name="debug_grilla"> Mostrar guías (debug)</label>
     <br>
     <button type="submit">Generar Montaje</button>
   </form>

--- a/tests/test_montaje_offset_inteligente.py
+++ b/tests/test_montaje_offset_inteligente.py
@@ -88,3 +88,45 @@ def test_calcular_posiciones_alinear_filas():
     assert xs[2] - xs[1] == pytest.approx(54)
     ys = {p["y"] for p in posiciones}
     assert len(ys) == 1
+
+
+def test_calcular_posiciones_forzar_grilla():
+    disenos = (
+        [{"archivo": "a.pdf", "ancho": 100, "alto": 50}] * 6
+        + [{"archivo": "b.pdf", "ancho": 80, "alto": 60}] * 4
+    )
+    posiciones = calcular_posiciones(
+        disenos,
+        500,
+        400,
+        margen=10,
+        separacion=5,
+        sangrado=0,
+        forzar_grilla=True,
+        debug=True,
+    )
+    assert len(posiciones) == 10
+
+    # Comprobamos que las columnas tienen el mismo ancho y separación
+    from collections import defaultdict
+
+    columnas = defaultdict(list)
+    for pos in posiciones:
+        columnas[round(pos["x"], 5)].append(pos)
+
+    xs = sorted(columnas.keys())
+    for i in range(len(xs) - 1):
+        ancho_col = columnas[xs[i]][0]["celda_ancho"]
+        assert xs[i] + ancho_col + 5 == pytest.approx(xs[i + 1])
+
+    # Todas las filas comparten altura y separación vertical
+    filas = defaultdict(list)
+    for pos in posiciones:
+        # El borde superior de la fila coincide con el borde superior del diseño
+        top = pos["y"] + pos["alto"]
+        filas[round(top, 5)].append(pos)
+
+    tops = sorted(filas.keys(), reverse=True)
+    for i in range(len(tops) - 1):
+        alto_f = filas[tops[i]][0]["celda_alto"]
+        assert tops[i] - alto_f - 5 == pytest.approx(tops[i + 1])


### PR DESCRIPTION
## Summary
- allow forcing professional table-like layout in `calcular_posiciones`
- expose `forzar_grilla` and optional debugging guides through UI and backend
- add tests for grid placement

## Testing
- `pytest -q`
- `python - <<'PY' ... PY` (generate sample montage and grid positions)


------
https://chatgpt.com/codex/tasks/task_e_68942bc55e3883229f1b037a3a3d3493