### PR TITLE
Add spacing and margin controls to offset layout

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -222,6 +222,13 @@ def montaje_offset_inteligente_view():
     centrar_montaje = request.form.get("centrar_montaje") == "on"
     forzar_grilla = request.form.get("forzar_grilla") == "on"
     debug_grilla = request.form.get("debug_grilla") == "on"
+    espaciado_horizontal = float(request.form.get("espaciado_horizontal", 0))
+    espaciado_vertical = float(request.form.get("espaciado_vertical", 0))
+    margen_izq = float(request.form.get("margen_izq", 10))
+    margen_der = float(request.form.get("margen_der", 10))
+    margen_sup = float(request.form.get("margen_sup", 10))
+    margen_inf = float(request.form.get("margen_inf", 10))
+    preferir_horizontal = bool(request.form.get("preferir_horizontal"))
 
     output_path = os.path.join("output", "pliego_offset_inteligente.pdf")
     montar_pliego_offset_inteligente(
@@ -234,6 +241,13 @@ def montaje_offset_inteligente_view():
         centrar=centrar_montaje,
         forzar_grilla=forzar_grilla,
         debug_grilla=debug_grilla,
+        espaciado_horizontal=espaciado_horizontal,
+        espaciado_vertical=espaciado_vertical,
+        margen_izq=margen_izq,
+        margen_der=margen_der,
+        margen_sup=margen_sup,
+        margen_inf=margen_inf,
+        preferir_horizontal=preferir_horizontal,
         output_path=output_path,
     )
     return send_file(output_path, as_attachment=True)

--- a/templates/montaje_offset_inteligente.html
+++ b/templates/montaje_offset_inteligente.html
@@ -45,6 +45,25 @@
     <label>Separación doble corte (mm):</label>
     <input type="number" name="separacion" value="4" step="0.01">
     <br>
+    <label>Espaciado horizontal (mm):</label>
+    <input type="number" name="espaciado_horizontal" value="0" step="0.01">
+    <br>
+    <label>Espaciado vertical (mm):</label>
+    <input type="number" name="espaciado_vertical" value="0" step="0.01">
+    <br>
+    <label>Margen izquierdo (mm):</label>
+    <input type="number" name="margen_izq" value="10" step="0.01">
+    <br>
+    <label>Margen derecho (mm):</label>
+    <input type="number" name="margen_der" value="10" step="0.01">
+    <br>
+    <label>Margen superior (mm):</label>
+    <input type="number" name="margen_sup" value="10" step="0.01">
+    <br>
+    <label>Margen inferior (mm):</label>
+    <input type="number" name="margen_inf" value="10" step="0.01">
+    <br>
+    <label><input type="checkbox" name="preferir_horizontal"> Preferir orientación horizontal</label><br>
     <label><input type="checkbox" name="ordenar_tamano"> Ordenar por tamaño</label><br>
     <label><input type="checkbox" name="alinear_filas"> Alinear por filas</label><br>
     <label><input type="checkbox" name="centrar_montaje"> Centrar montaje en pliego</label><br>


### PR DESCRIPTION
## Summary
- support horizontal/vertical spacing, individual margins and orientation preference in smart offset layout
- wire form fields and route handler to pass new parameters
- add regression test covering new parameters

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68943883b4fc8322a863befcd230c9ef