### PR TITLE
feat: add optional rotation to offset layout

### DIFF
--- a/tests/test_montaje_offset_inteligente.py
+++ b/tests/test_montaje_offset_inteligente.py
@@ -13,7 +13,11 @@ os.environ.setdefault("OPENAI_API_KEY", "test")
 
 import pytest
 from app import app
-from montaje_offset_inteligente import obtener_dimensiones_pdf, calcular_posiciones
+from montaje_offset_inteligente import (
+    obtener_dimensiones_pdf,
+    calcular_posiciones,
+    montar_pliego_offset_inteligente,
+)
 
 
 def test_obtener_dimensiones_pdf():
@@ -172,3 +176,51 @@ def test_calcular_posiciones_forzar_grilla():
     for i in range(len(tops) - 1):
         alto_f = filas[tops[i]][0]["celda_alto"]
         assert tops[i] - alto_f - 5 == pytest.approx(tops[i + 1])
+
+
+def _crear_pdf_temporal(ancho_mm: float, alto_mm: float) -> str:
+    tmp = tempfile.NamedTemporaryFile(suffix=".pdf", delete=False)
+    c = canvas.Canvas(tmp.name, pagesize=(ancho_mm * mm, alto_mm * mm))
+    c.drawString(10, 10, "test")
+    c.save()
+    tmp.close()
+    return tmp.name
+
+
+def test_montar_pliego_sin_rotacion_generando_sobrantes(tmp_path):
+    pdf = _crear_pdf_temporal(70, 50)
+    resumen = tmp_path / "resumen.html"
+    montar_pliego_offset_inteligente(
+        [(pdf, 2)],
+        130,
+        90,
+        separacion=0,
+        sangrado=1,
+        margen_izq=10,
+        margen_der=10,
+        margen_sup=5,
+        margen_inf=5,
+        resumen_path=str(resumen),
+    )
+    contenido = resumen.read_text(encoding="utf-8")
+    assert "No se pudieron colocar" in contenido
+
+
+def test_montar_pliego_con_rotacion_coloca_todas(tmp_path):
+    pdf = _crear_pdf_temporal(70, 50)
+    resumen = tmp_path / "resumen.html"
+    montar_pliego_offset_inteligente(
+        [(pdf, 2)],
+        130,
+        90,
+        separacion=0,
+        sangrado=1,
+        margen_izq=10,
+        margen_der=10,
+        margen_sup=5,
+        margen_inf=5,
+        permitir_rotacion=True,
+        resumen_path=str(resumen),
+    )
+    contenido = resumen.read_text(encoding="utf-8")
+    assert "No se pudieron colocar" not in contenido


### PR DESCRIPTION
## Summary
- allow optional orientation rotation to increase copies per row in offset layout
- rotate images during rendering when rotation is used
- cover rotation and non-rotation scenarios with new tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894454a50848322857f059edfb10936