### PR TITLE
Refactor offset layout options and add advanced marks

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -211,24 +211,61 @@ def _parse_montaje_offset_form(req):
         repeticiones = int(req.form.get(f"repeticiones_{i}", 1))
         diseños.append((path, repeticiones))
 
+    estrategia = req.form.get("estrategia", "flujo")
+    if req.form.get("forzar_grilla"):
+        estrategia = "grid"
+
+    ordenar_tamano = bool(req.form.get("ordenar_tamano"))
+    alinear_filas = bool(req.form.get("alinear_filas"))
+    preferir_horizontal = bool(req.form.get("preferir_horizontal"))
+
+    centrar = True
+    if "centrar" in req.form or "centrar_montaje" in req.form:
+        centrar = bool(req.form.get("centrar") or req.form.get("centrar_montaje"))
+
+    filas = int(req.form.get("filas", 0) or 0)
+    columnas = int(req.form.get("columnas", 0) or 0)
+    celda_ancho = float(req.form.get("celda_ancho", 0) or 0)
+    celda_alto = float(req.form.get("celda_alto", 0) or 0)
+
+    pinza_mm = float(req.form.get("pinza_mm", 0) or 0)
+    lateral_mm = float(req.form.get("lateral_mm", 0) or 0)
+    marcas_registro = bool(req.form.get("marcas_registro"))
+    marcas_corte = bool(req.form.get("marcas_corte"))
+    debug_grilla = bool(req.form.get("debug_grilla"))
+
+    if estrategia == "flujo":
+        ordenar_tamano = False if "ordenar_tamano" not in req.form else ordenar_tamano
+        alinear_filas = True if "alinear_filas" not in req.form else alinear_filas
+    elif estrategia == "grid":
+        alinear_filas = False
+    elif estrategia == "maxrects":
+        ordenar_tamano = True if "ordenar_tamano" not in req.form else ordenar_tamano
+        alinear_filas = False
+        preferir_horizontal = False
+
     params = {
         "separacion": float(req.form.get("separacion", 4)),
-        "ordenar_tamano": req.form.get("ordenar_tamano") == "on",
-        "alinear_filas": req.form.get("alinear_filas") == "on",
-        "centrar_montaje": req.form.get("centrar_montaje") == "on",
-        "forzar_grilla": req.form.get("forzar_grilla") == "on",
-        "debug_grilla": req.form.get("debug_grilla") == "on",
+        "ordenar_tamano": ordenar_tamano,
+        "alinear_filas": alinear_filas,
+        "preferir_horizontal": preferir_horizontal,
+        "centrar": centrar,
+        "debug_grilla": debug_grilla,
         "espaciado_horizontal": float(req.form.get("espaciado_horizontal", 0)),
         "espaciado_vertical": float(req.form.get("espaciado_vertical", 0)),
         "margen_izq": float(req.form.get("margen_izq", 10)),
         "margen_der": float(req.form.get("margen_der", 10)),
         "margen_sup": float(req.form.get("margen_sup", 10)),
         "margen_inf": float(req.form.get("margen_inf", 10)),
-        "estrategia": req.form.get("estrategia", "flujo"),
-        "filas": int(req.form.get("filas", 0) or 0),
-        "columnas": int(req.form.get("columnas", 0) or 0),
-        "celda_ancho": float(req.form.get("celda_ancho", 0) or 0),
-        "celda_alto": float(req.form.get("celda_alto", 0) or 0),
+        "estrategia": estrategia,
+        "filas": filas,
+        "columnas": columnas,
+        "celda_ancho": celda_ancho,
+        "celda_alto": celda_alto,
+        "pinza_mm": pinza_mm,
+        "lateral_mm": lateral_mm,
+        "marcas_registro": marcas_registro,
+        "marcas_corte": marcas_corte,
     }
 
     return diseños, ancho_pliego, alto_pliego, params
@@ -251,8 +288,8 @@ def montaje_offset_inteligente_view():
         separacion=params["separacion"],
         ordenar_tamano=params["ordenar_tamano"],
         alinear_filas=params["alinear_filas"],
-        centrar=params["centrar_montaje"],
-        forzar_grilla=params["forzar_grilla"],
+        preferir_horizontal=params["preferir_horizontal"],
+        centrar=params["centrar"],
         debug_grilla=params["debug_grilla"],
         espaciado_horizontal=params["espaciado_horizontal"],
         espaciado_vertical=params["espaciado_vertical"],
@@ -265,6 +302,10 @@ def montaje_offset_inteligente_view():
         columnas=params["columnas"],
         celda_ancho=params["celda_ancho"],
         celda_alto=params["celda_alto"],
+        pinza_mm=params["pinza_mm"],
+        lateral_mm=params["lateral_mm"],
+        marcas_registro=params["marcas_registro"],
+        marcas_corte=params["marcas_corte"],
         output_path=output_path,
     )
     return send_file(output_path, as_attachment=True)
@@ -281,8 +322,8 @@ def montaje_offset_preview():
             separacion=params["separacion"],
             ordenar_tamano=params["ordenar_tamano"],
             alinear_filas=params["alinear_filas"],
-            centrar=params["centrar_montaje"],
-            forzar_grilla=params["forzar_grilla"],
+            preferir_horizontal=params["preferir_horizontal"],
+            centrar=params["centrar"],
             debug_grilla=params["debug_grilla"],
             espaciado_horizontal=params["espaciado_horizontal"],
             espaciado_vertical=params["espaciado_vertical"],
@@ -295,6 +336,10 @@ def montaje_offset_preview():
             columnas=params["columnas"],
             celda_ancho=params["celda_ancho"],
             celda_alto=params["celda_alto"],
+            pinza_mm=params["pinza_mm"],
+            lateral_mm=params["lateral_mm"],
+            marcas_registro=params["marcas_registro"],
+            marcas_corte=params["marcas_corte"],
             preview_only=True,
         )
         b64 = base64.b64encode(png_bytes).decode("ascii")

--- a/templates/montaje_offset_inteligente.html
+++ b/templates/montaje_offset_inteligente.html
@@ -63,30 +63,57 @@
     <label>Margen inferior (mm):</label>
     <input type="number" name="margen_inf" value="10" step="0.01">
     <br>
-    <label><input type="checkbox" name="preferir_horizontal"> Preferir orientación horizontal</label><br>
-    <label><input type="checkbox" name="ordenar_tamano"> Ordenar por tamaño</label><br>
-    <label><input type="checkbox" name="alinear_filas"> Alinear por filas</label><br>
-    <label><input type="checkbox" name="centrar_montaje"> Centrar montaje en pliego</label><br>
-    <label><input type="checkbox" name="forzar_grilla"> Forzar grilla</label><br>
-    <label><input type="checkbox" name="debug_grilla"> Mostrar guías (debug)</label>
-    <br>
+    <label><input type="checkbox" name="centrar" checked> Centrar montaje en pliego</label><br>
     <label>Estrategia de montaje:</label>
-    <select name="estrategia" id="estrategia">
+    <select name="estrategia">
       <option value="flujo">Flujo (auto)</option>
       <option value="grid">Grid (filas/columnas o celda fija)</option>
       <option value="maxrects">MaxRects (anidado eficiente)</option>
     </select>
-    <div id="grid-options" style="display:none;">
-      <label>Filas:</label>
-      <input type="number" name="filas" min="0" value="0">
-      <label>Columnas:</label>
-      <input type="number" name="columnas" min="0" value="0">
-      <br>
-      <label>Ancho celda (mm):</label>
-      <input type="number" name="celda_ancho" step="0.01">
-      <label>Alto celda (mm):</label>
-      <input type="number" name="celda_alto" step="0.01">
+
+    <!-- Controles comunes: mantener márgenes, separaciones, etc. -->
+
+    <!-- Grupo Flujo -->
+    <div id="grupo-flujo">
+      <label><input type="checkbox" name="alinear_filas" checked title="Alinea por la altura mayor de cada fila"> Alinear por filas</label>
+      <label><input type="checkbox" name="preferir_horizontal" title="Si hay rotación, prioriza ancho>alto"> Preferir orientación horizontal</label>
     </div>
+
+    <!-- Grupo Grid -->
+    <div id="grupo-grid" style="display:none;">
+      <div>
+        <label>Filas (opcional): <input type="number" name="filas" min="0" step="1" value="0"></label>
+        <label>Columnas (opcional): <input type="number" name="columnas" min="0" step="1" value="0"></label>
+      </div>
+      <div>
+        <small>O usar celda fija (sin reescalar):</small><br>
+        <label>Ancho celda (mm): <input type="number" name="celda_ancho" min="0" step="0.1" value="0"></label>
+        <label>Alto celda (mm): <input type="number" name="celda_alto" min="0" step="0.1" value="0"></label>
+      </div>
+      <label><input type="checkbox" name="preferir_horizontal" title="Si hay rotación, prioriza ancho>alto"> Preferir orientación horizontal</label>
+    </div>
+
+    <!-- Grupo MaxRects -->
+    <div id="grupo-maxrects" style="display:none;">
+      <small>Consejo: activar “Ordenar por tamaño” para mejor aprovechamiento.</small><br>
+      <label><input type="checkbox" name="ordenar_tamano" checked title="Coloca primero piezas grandes para reducir huecos"> Ordenar por tamaño</label>
+    </div>
+
+    <details style="margin-top:12px;">
+      <summary>Opciones avanzadas (Offset)</summary>
+      <div style="margin-top:8px;">
+        <label>Reserva pinza (mm): <input type="number" name="pinza_mm" min="0" step="0.1" value="0" title="Reserva en el borde de pinza (parte inferior del pliego en orientación de trabajo)"></label>
+        <label>Reserva lateral (mm): <input type="number" name="lateral_mm" min="0" step="0.1" value="0" title="Reserva lateral para pinza/guía lateral"></label>
+        <div style="margin-top:6px;">
+          <label><input type="checkbox" name="marcas_registro"> Añadir marcas de registro</label>
+          <label><input type="checkbox" name="marcas_corte"> Añadir marcas de corte</label>
+        </div>
+        <div style="margin-top:6px;">
+          <label><input type="checkbox" name="debug_grilla"> Mostrar guías (debug)</label>
+        </div>
+      </div>
+    </details>
+
     <br>
     <div style="margin-top:12px; display:flex; gap:8px; flex-wrap:wrap;">
       <button id="btn-preview" type="button">Vista previa</button>
@@ -108,10 +135,40 @@
       document.getElementById('pliego-personalizado').style.display =
         this.value === 'personalizado' ? 'block' : 'none';
     });
-    document.getElementById('estrategia').addEventListener('change', function() {
-      document.getElementById('grid-options').style.display =
-        this.value === 'grid' ? 'block' : 'none';
-    });
+
+    const selE = document.querySelector('select[name="estrategia"]');
+    const gFlujo = document.getElementById('grupo-flujo');
+    const gGrid = document.getElementById('grupo-grid');
+    const gMR = document.getElementById('grupo-maxrects');
+    const celdaAncho = document.querySelector('input[name="celda_ancho"]');
+    const celdaAlto = document.querySelector('input[name="celda_alto"]');
+    const filas = document.querySelector('input[name="filas"]');
+    const columnas = document.querySelector('input[name="columnas"]');
+
+    function setGroupState(group, active) {
+      group.style.display = active ? 'block' : 'none';
+      group.querySelectorAll('input').forEach(inp => inp.disabled = !active);
+    }
+
+    function toggleByStrategy() {
+      const v = selE.value;
+      setGroupState(gFlujo, v === 'flujo');
+      setGroupState(gGrid, v === 'grid');
+      setGroupState(gMR, v === 'maxrects');
+      if (v === 'grid') toggleGridInputs();
+    }
+
+    function toggleGridInputs() {
+      const usarCelda = parseFloat(celdaAncho.value) > 0 || parseFloat(celdaAlto.value) > 0;
+      filas.disabled = usarCelda;
+      columnas.disabled = usarCelda;
+    }
+
+    selE.addEventListener('change', toggleByStrategy);
+    celdaAncho.addEventListener('input', toggleGridInputs);
+    celdaAlto.addEventListener('input', toggleGridInputs);
+    toggleByStrategy();
+    toggleGridInputs();
 
     const form = document.querySelector('form');
     const btnPreview = document.getElementById('btn-preview');


### PR DESCRIPTION
## Summary
- Simplify offset intelligent UI by grouping strategy-specific controls and adding advanced options like pinza, lateral, and marks
- Parse strategy defaults in backend with compatibility mapping and forward new advanced flags to renderer
- Apply pinza/lateral reserves, orientation preference, and optional registration/cut marks in layout engine

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897b867f80c83229602f36562b0c522