### PR TITLE
Optimize offset preview memory usage and clean requirements

### DIFF
--- a/montaje_offset_inteligente.py
+++ b/montaje_offset_inteligente.py
@@ -698,9 +698,13 @@ def montar_pliego_offset_inteligente(
             d.rectangle([(x, y), (x + w, y + h)], outline="black", width=2)
 
         bio = io.BytesIO()
-        im.save(bio, format="PNG")
-        png_bytes = bio.getvalue()
-        return png_bytes, resumen_html
+        # JPEG liviano
+        im.save(bio, format="JPEG", quality=70, optimize=True, progressive=True)
+        jpg_bytes = bio.getvalue()
+        # liberar
+        im.close(); del im
+        bio.close()
+        return jpg_bytes, resumen_html
 
     # Creación del PDF final
     os.makedirs(os.path.dirname(output_path), exist_ok=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ reportlab==4.1.0
 Pillow==10.4.0
 PyMuPDF==1.26.1
 gunicorn==21.2.0
-nginx
 openai>=1.3.5
 numpy==1.26.4
 opencv-python-headless==4.9.0.80

--- a/routes.py
+++ b/routes.py
@@ -365,36 +365,43 @@ def montaje_offset_inteligente_view():
 @routes_bp.route("/montaje_offset/preview", methods=["POST"])
 def montaje_offset_preview():
     try:
-        diseños, ancho_pliego, alto_pliego, params = _parse_montaje_offset_form(request)
-        png_bytes, resumen_html = montar_pliego_offset_inteligente(
-            diseños,
-            ancho_pliego,
-            alto_pliego,
-            separacion=params["separacion"],
-            ordenar_tamano=params["ordenar_tamano"],
-            alinear_filas=params["alinear_filas"],
-            preferir_horizontal=params["preferir_horizontal"],
-            centrar=params["centrar"],
-            debug_grilla=params["debug_grilla"],
-            espaciado_horizontal=params["espaciado_horizontal"],
-            espaciado_vertical=params["espaciado_vertical"],
-            margen_izq=params["margen_izq"],
-            margen_der=params["margen_der"],
-            margen_sup=params["margen_sup"],
-            margen_inf=params["margen_inf"],
-            estrategia=params["estrategia"],
-            filas=params["filas"],
-            columnas=params["columnas"],
-            celda_ancho=params["celda_ancho"],
-            celda_alto=params["celda_alto"],
-            pinza_mm=params["pinza_mm"],
-            lateral_mm=params["lateral_mm"],
-            marcas_registro=params["marcas_registro"],
-            marcas_corte=params["marcas_corte"],
-            preview_only=True,
-        )
+        with heavy_lock:
+            diseños, ancho_pliego, alto_pliego, params = _parse_montaje_offset_form(request)
+            png_bytes, resumen_html = montar_pliego_offset_inteligente(
+                diseños,
+                ancho_pliego,
+                alto_pliego,
+                separacion=params["separacion"],
+                ordenar_tamano=params["ordenar_tamano"],
+                alinear_filas=params["alinear_filas"],
+                preferir_horizontal=params["preferir_horizontal"],
+                centrar=params["centrar"],
+                debug_grilla=params["debug_grilla"],
+                espaciado_horizontal=params["espaciado_horizontal"],
+                espaciado_vertical=params["espaciado_vertical"],
+                margen_izq=params["margen_izq"],
+                margen_der=params["margen_der"],
+                margen_sup=params["margen_sup"],
+                margen_inf=params["margen_inf"],
+                estrategia=params["estrategia"],
+                filas=params["filas"],
+                columnas=params["columnas"],
+                celda_ancho=params["celda_ancho"],
+                celda_alto=params["celda_alto"],
+                pinza_mm=params["pinza_mm"],
+                lateral_mm=params["lateral_mm"],
+                marcas_registro=params["marcas_registro"],
+                marcas_corte=params["marcas_corte"],
+                preview_only=True,
+            )
         b64 = base64.b64encode(png_bytes).decode("ascii")
-        return jsonify({"ok": True, "preview_data": f"data:image/png;base64,{b64}", "resumen_html": resumen_html or ""})
+        return jsonify(
+            {
+                "ok": True,
+                "preview_data": f"data:image/jpeg;base64,{b64}",
+                "resumen_html": resumen_html or "",
+            }
+        )
     except TypeError as e:
         return jsonify({"ok": False, "error": f"TypeError: {str(e)}"}), 500
     except Exception as e:
@@ -524,7 +531,7 @@ def montaje_flexo_avanzado():
 
     return render_template(
         "montaje_flexo_avanzado.html",
-        preview=preview_b64,
+        preview=f"data:image/png;base64,{preview_b64}",
         pistas=cantidad_pistas,
         etiquetas_por_repeticion=etiquetas_por_repeticion,
         repeticiones=repeticiones,

--- a/templates/montaje_flexo_avanzado.html
+++ b/templates/montaje_flexo_avanzado.html
@@ -146,7 +146,7 @@
     {% if preview %}
     <div class="preview">
       <h3>Vista previa</h3>
-      <img src="data:image/png;base64,{{preview}}" alt="Vista previa del montaje">
+        <img src="{{ preview }}" alt="Vista previa del montaje">
       <p>Pistas: {{pistas}} | Etiquetas por repetición: {{etiquetas_por_repeticion}} | Repeticiones: {{repeticiones}} | Metros: {{metros_totales}} m | Alineación: {{alignment}}</p>
       <div class="descargas">
         <a href="/descargar_montaje_flexo_avanzado">Descargar Montaje PDF</a>

--- a/templates/montaje_offset_inteligente.html
+++ b/templates/montaje_offset_inteligente.html
@@ -194,7 +194,7 @@
 
         // Imagen
         const img = document.createElement('img');
-        img.src = data.preview_data;  // "data:image/png;base64,...."
+          img.src = data.preview_data;  // "data:image/*;base64,..."
         img.style.maxWidth = '100%';
         img.alt = 'Vista previa del montaje';
         previewPanel.appendChild(img);


### PR DESCRIPTION
## Summary
- remove nginx from requirements to streamline dependencies
- wrap offset preview generation in heavy_lock and return JPEG previews
- encode offset preview as JPEG with memory cleanup and generalize preview templates

## Testing
- `pytest >/tmp/unit.log && tail -n 20 /tmp/unit.log`

------
https://chatgpt.com/codex/tasks/task_e_6897dc4e0cc883228e3f45b96b305a8d