### PR TITLE
Improve offset auto preview and layout margins

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -172,6 +172,11 @@ def descargar_pdf():
     return send_file("output/montado.pdf", as_attachment=True)
 
 
+@routes_bp.route('/outputs/<path:filename>')
+def outputs_static(filename):
+    return send_from_directory('outputs', filename)
+
+
 @routes_bp.route("/montaje_offset", methods=["GET", "POST"])
 def montaje_offset_view():
     if request.method == "GET":

--- a/templates/imposicion_offset_auto_result.html
+++ b/templates/imposicion_offset_auto_result.html
@@ -3,7 +3,9 @@
 <body>
   <h2>Resultado de Imposición Offset Automática</h2>
   {% set r = data.get('resumen', {}) %}
-  <p><strong>Pliego PDF:</strong> {{ data.pliego_pdf }}</p>
-  <p><img src="{{ data.preview_png | replace('\\', '/') }}" alt="preview" style="max-width: 80%; border:1px solid #ccc;"></p>
+  {% set pdf_rel = data.pliego_pdf.split('outputs/')[1] %}
+  {% set png_rel = data.preview_png.split('outputs/')[1] %}
+  <p><a href="{{ url_for('routes.outputs_static', filename=pdf_rel) }}" target="_blank">Descargar PDF</a></p>
+  <p><img src="{{ url_for('routes.outputs_static', filename=png_rel) }}" alt="preview" style="max-width: 80%; border:1px solid #ccc;"></p>
   <pre>{{ r | tojson(indent=2) }}</pre>
 </body></html>

--- a/utils_img.py
+++ b/utils_img.py
@@ -23,3 +23,38 @@ def dpi_for_raster_ops(page_mm, max_pixels=12_000_000):
         scale = math.sqrt(max_pixels / est_px)
         target_dpi = max(150, int(target_dpi * scale))
     return target_dpi
+
+import os
+
+
+def render_pdf_first_page_to_png(pdf_path: str, out_png: str, dpi: int = 150) -> None:
+    """
+    Intenta rasterizar con pdf2image (Poppler). Si falla o no está Poppler,
+    hace fallback a PyMuPDF (fitz). No lanza excepción si no hay páginas.
+    """
+    # 1) Intento: pdf2image
+    try:
+        from pdf2image import convert_from_path  # import lazy
+        imgs = convert_from_path(pdf_path, dpi=dpi, first_page=1, last_page=1)
+        if imgs:
+            imgs[0].save(out_png)
+            return
+    except Exception as e:
+        # Errores típicos sin Poppler:
+        # - "Unable to get page count. Is poppler installed..."
+        # - "No such file or directory: 'pdftoppm'"
+        pass
+
+    # 2) Fallback: PyMuPDF
+    import fitz
+    doc = fitz.open(pdf_path)
+    if doc.page_count == 0:
+        doc.close()
+        return
+    page = doc.load_page(0)
+    zoom = dpi / 72.0
+    mat = fitz.Matrix(zoom, zoom)
+    pix = page.get_pixmap(matrix=mat, alpha=False)
+    pix.save(out_png)
+    doc.close()
+


### PR DESCRIPTION
## Summary
- Add `render_pdf_first_page_to_png` helper with pdf2image/fitz fallback
- Use helper in automatic offset imposition and fix registration marks and guide margins
- Expose generated outputs via Flask route and update result template

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689818e28f388322b12c7637c191a9ae