### PR TITLE
feat: add optional bleed controls

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -291,6 +291,16 @@ def _parse_montaje_offset_form(req):
     marcas_corte = bool(req.form.get("marcas_corte"))
     debug_grilla = bool(req.form.get("debug_grilla"))
 
+    # Opciones de sangrado
+    modo_sangrado = req.form.get("modo_sangrado", "original")
+    sangrado_mm = 0.0
+    usar_trimbox = False
+    if modo_sangrado == "add":
+        sangrado_mm = float(req.form.get("sangrado_add", 0) or 0)
+    elif modo_sangrado == "replace":
+        sangrado_mm = float(req.form.get("sangrado_replace", 0) or 0)
+        usar_trimbox = True
+
     if estrategia == "flujo":
         ordenar_tamano = False if "ordenar_tamano" not in req.form else ordenar_tamano
         alinear_filas = True if "alinear_filas" not in req.form else alinear_filas
@@ -323,6 +333,8 @@ def _parse_montaje_offset_form(req):
         "lateral_mm": lateral_mm,
         "marcas_registro": marcas_registro,
         "marcas_corte": marcas_corte,
+        "sangrado": sangrado_mm,
+        "usar_trimbox": usar_trimbox,
     }
 
     return diseños, ancho_pliego, alto_pliego, params
@@ -343,6 +355,8 @@ def montaje_offset_inteligente_view():
         ancho_pliego,
         alto_pliego,
         separacion=params["separacion"],
+        sangrado=params["sangrado"],
+        usar_trimbox=params["usar_trimbox"],
         ordenar_tamano=params["ordenar_tamano"],
         alinear_filas=params["alinear_filas"],
         preferir_horizontal=params["preferir_horizontal"],
@@ -378,6 +392,8 @@ def montaje_offset_preview():
                 ancho_pliego,
                 alto_pliego,
                 separacion=params["separacion"],
+                sangrado=params["sangrado"],
+                usar_trimbox=params["usar_trimbox"],
                 ordenar_tamano=params["ordenar_tamano"],
                 alinear_filas=params["alinear_filas"],
                 preferir_horizontal=params["preferir_horizontal"],

--- a/templates/montaje_offset_inteligente.html
+++ b/templates/montaje_offset_inteligente.html
@@ -63,6 +63,14 @@
     <label>Margen inferior (mm):</label>
     <input type="number" name="margen_inf" value="10" step="0.01">
     <br>
+
+    <fieldset style="margin-top:10px;">
+      <legend>Sangrado</legend>
+      <label><input type="radio" name="modo_sangrado" value="original" checked> Usar sangrado original del archivo</label><br>
+      <label><input type="radio" name="modo_sangrado" value="add"> Añadir sangrado de: <input type="number" name="sangrado_add" min="0" step="0.1" disabled> mm</label><br>
+      <label><input type="radio" name="modo_sangrado" value="replace"> Reemplazar sangrado existente con: <input type="number" name="sangrado_replace" min="0" step="0.1" disabled> mm</label>
+    </fieldset>
+
     <label><input type="checkbox" name="centrar" checked> Centrar montaje en pliego</label><br>
     <label>Estrategia de montaje:</label>
     <select name="estrategia">
@@ -144,6 +152,15 @@
     const celdaAlto = document.querySelector('input[name="celda_alto"]');
     const filas = document.querySelector('input[name="filas"]');
     const columnas = document.querySelector('input[name="columnas"]');
+    const radiosSangrado = document.querySelectorAll('input[name="modo_sangrado"]');
+
+    function actualizarSangradoInputs() {
+      const modo = document.querySelector('input[name="modo_sangrado"]:checked').value;
+      document.querySelector('input[name="sangrado_add"]').disabled = modo !== 'add';
+      document.querySelector('input[name="sangrado_replace"]').disabled = modo !== 'replace';
+    }
+    radiosSangrado.forEach(r => r.addEventListener('change', actualizarSangradoInputs));
+    actualizarSangradoInputs();
 
     function setGroupState(group, active) {
       group.style.display = active ? 'block' : 'none';

--- a/tests/test_montaje_offset_inteligente.py
+++ b/tests/test_montaje_offset_inteligente.py
@@ -237,9 +237,9 @@ def test_montar_pliego_offset_cache(monkeypatch, tmp_path):
     original = montaje_offset_inteligente._pdf_a_imagen_con_sangrado
     calls = {"count": 0}
 
-    def wrapper(path, sangrado):
+    def wrapper(path, sangrado, *args, **kwargs):
         calls["count"] += 1
-        return original(path, sangrado)
+        return original(path, sangrado, *args, **kwargs)
 
     monkeypatch.setattr(
         montaje_offset_inteligente, "_pdf_a_imagen_con_sangrado", wrapper


### PR DESCRIPTION
## Summary
- add configurable bleed options in intelligent offset layout form
- support replacing bleed using TrimBox and optional cropping in backend
- adjust tests for bleed options

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898434980388322bb1d22fff04dd922