### PR TITLE
Implement customizable PRO offset montage mode

### DIFF
--- a/montaje_offset_personalizado.py
+++ b/montaje_offset_personalizado.py
@@ -1,64 +1,222 @@
+"""Módulo para el modo de montaje offset PRO totalmente personalizado.
+
+Este modo es independiente del montaje estándar y permite controlar cada
+detalle del pliego: repeticiones exactas por archivo, márgenes, separación y
+alineación personalizada. Si no es posible colocar todas las repeticiones en un
+único pliego se genera un ``ValueError`` y no se crea ningún PDF.
+"""
+
+import math
 import os
 import tempfile
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 from PyPDF2 import PdfReader, PdfWriter
+from reportlab.pdfgen import canvas
+from reportlab.lib import colors
 
-from montaje_offset_inteligente import montar_pliego_offset_inteligente
+from montaje_offset_inteligente import (
+    mm_to_pt,
+    detectar_sangrado_pdf,
+    obtener_dimensiones_pdf,
+    _pdf_a_imagen_con_sangrado,
+    draw_cutmarks_around_form_reportlab,
+    _bbox_add,
+    recortar_pdf_a_bbox,
+)
 
 
-def montar_pliego_offset_personalizado(specs: List[Dict], pro_config: Dict) -> str:
-    """Modo super personalizado básico reutilizando motor estándar.
+def _rotar_pdf_si_corresponde(path: str) -> None:
+    """Rota 90° un PDF sobre sí mismo si es necesario."""
+
+    reader = PdfReader(path)
+    writer = PdfWriter()
+    for page in reader.pages:
+        try:
+            page.rotate_clockwise(90)
+        except Exception:
+            page.rotate(90)
+        writer.add_page(page)
+    with open(path, "wb") as out_f:
+        writer.write(out_f)
+
+
+def montar_pliego_offset_personalizado(
+    specs: List[Dict], pro_config: Dict
+) -> Tuple[str, List[Dict]]:
+    """Genera un pliego en modo PRO totalmente personalizado.
 
     Parameters
     ----------
-    specs: lista de dicts por archivo
-    pro_config: configuración general del pliego
+    specs: list[dict]
+        Lista de especificaciones por archivo. Cada dict acepta las claves
+        ``file``, ``filename``, ``reps``, ``rotate``, ``bleed_mm``, ``cutmarks``
+        y ``align``.
+    pro_config: dict
+        Configuración global del pliego.
 
     Returns
     -------
-    str
-        Ruta del PDF generado.
+    tuple(str, list[dict])
+        Ruta al PDF generado y un resumen de montado.
     """
-    diseños = []
+
+    # --- Lectura de configuración global ---
+    pliego_w = float(pro_config.get("pliego_w_mm", 0))
+    pliego_h = float(pro_config.get("pliego_h_mm", 0))
+    margen_izq = float(pro_config.get("margen_izq_mm", 0))
+    margen_der = float(pro_config.get("margen_der_mm", margen_izq))
+    margen_sup = float(pro_config.get("margen_sup_mm", 0))
+    margen_inf = float(pro_config.get("margen_inf_mm", margen_sup))
+    sep_h = float(pro_config.get("sep_h_mm", 0))
+    sep_v = float(pro_config.get("sep_v_mm", 0))
+    export_area_util = bool(pro_config.get("export_area_util", False))
+    preview = bool(pro_config.get("preview", False))
+
+    pliego_w_pt = mm_to_pt(pliego_w)
+    pliego_h_pt = mm_to_pt(pliego_h)
+
+    available_w = pliego_w - margen_izq - margen_der
+    current_y = margen_sup
+
+    output_path = os.path.join("output", "pliego_offset_pro.pdf")
+    c = canvas.Canvas(output_path, pagesize=(pliego_w_pt, pliego_h_pt))
+    bbox = [None, None, None, None]
+
+    colores_preview = [
+        colors.red,
+        colors.blue,
+        colors.green,
+        colors.magenta,
+        colors.orange,
+        colors.purple,
+        colors.cyan,
+        colors.brown,
+    ]
+
+    resumen: List[Dict] = []
     tmp_paths: List[str] = []
-    for spec in specs:
+
+    for idx, spec in enumerate(specs):
         file_storage = spec.get("file")
+        reps = int(spec.get("reps") or 0)
+        if reps <= 0:
+            raise ValueError("Repeticiones inválidas en especificación")
+
         tmp_fd, tmp_path = tempfile.mkstemp(suffix=".pdf")
         with os.fdopen(tmp_fd, "wb") as tmp:
             tmp.write(file_storage.read())
+
         if spec.get("rotate"):
-            reader = PdfReader(tmp_path)
-            writer = PdfWriter()
-            for page in reader.pages:
-                try:
-                    page.rotate_clockwise(90)
-                except Exception:
-                    page.rotate(90)
-                writer.add_page(page)
-            with open(tmp_path, "wb") as out_f:
-                writer.write(out_f)
-        repeticiones = spec.get("reps") or 1
-        diseños.append((tmp_path, repeticiones))
+            _rotar_pdf_si_corresponde(tmp_path)
+
+        bleed_mm = spec.get("bleed_mm")
+        usar_trimbox = True
+        if bleed_mm is None:
+            bleed_mm = detectar_sangrado_pdf(tmp_path)
+            usar_trimbox = False
+
+        bleed_pt = mm_to_pt(bleed_mm)
+
+        # Dimensiones y rasterización según el sangrado
+        if usar_trimbox:
+            w_trim_mm, h_trim_mm = obtener_dimensiones_pdf(tmp_path, usar_trimbox=True)
+            w_total_mm = w_trim_mm + 2 * bleed_mm
+            h_total_mm = h_trim_mm + 2 * bleed_mm
+            img = _pdf_a_imagen_con_sangrado(
+                tmp_path, sangrado_mm=bleed_mm, usar_trimbox=True
+            )
+        else:
+            w_total_mm, h_total_mm = obtener_dimensiones_pdf(tmp_path)
+            w_trim_mm, h_trim_mm = obtener_dimensiones_pdf(tmp_path, usar_trimbox=True)
+            img = _pdf_a_imagen_con_sangrado(
+                tmp_path, sangrado_mm=0, usar_trimbox=False
+            )
+
+        w_total_pt = mm_to_pt(w_total_mm)
+        h_total_pt = mm_to_pt(h_total_mm)
+        w_trim_pt = mm_to_pt(w_trim_mm)
+        h_trim_pt = mm_to_pt(h_trim_mm)
+
+        max_cols = math.floor((available_w + sep_h) / (w_total_mm + sep_h))
+        if max_cols <= 0:
+            raise ValueError("No caben todas las repeticiones en el pliego personalizado")
+        rows_needed = math.ceil(reps / max_cols)
+        total_height = rows_needed * h_total_mm + (rows_needed - 1) * sep_v
+        if current_y + total_height > pliego_h - margen_inf:
+            raise ValueError("No caben todas las repeticiones en el pliego personalizado")
+
+        posiciones: List[Tuple[float, float]] = []  # en mm (top-left)
+        restante = reps
+        y_fila = current_y
+        for r in range(rows_needed):
+            cols_en_fila = min(restante, max_cols)
+            fila_ancho = cols_en_fila * w_total_mm + (cols_en_fila - 1) * sep_h
+            align = spec.get("align", "center")
+            if align == "left":
+                x_inicio = margen_izq
+            elif align == "right":
+                x_inicio = pliego_w - margen_der - fila_ancho
+            else:  # center
+                x_inicio = margen_izq + (available_w - fila_ancho) / 2
+
+            x_col = x_inicio
+            for _ in range(cols_en_fila):
+                posiciones.append((x_col, y_fila))
+                x_col += w_total_mm + sep_h
+
+            restante -= cols_en_fila
+            if r < rows_needed - 1:
+                y_fila += h_total_mm + sep_v
+            else:
+                y_fila += h_total_mm
+
+        current_y = y_fila + sep_v
+
+        color = colores_preview[idx % len(colores_preview)]
+        for x_mm, y_mm in posiciones:
+            x_pt = mm_to_pt(x_mm)
+            # Convertir coordenadas: de sistema top-left a bottom-left
+            y_pt = pliego_h_pt - mm_to_pt(y_mm) - h_total_pt
+            c.drawImage(img, x_pt, y_pt, width=w_total_pt, height=h_total_pt)
+
+            if preview:
+                c.setStrokeColor(color)
+                c.setLineWidth(1)
+                c.rect(
+                    x_pt + bleed_pt,
+                    y_pt + bleed_pt,
+                    w_trim_pt,
+                    h_trim_pt,
+                    stroke=1,
+                    fill=0,
+                )
+
+            if spec.get("cutmarks") and bleed_mm > 0:
+                draw_cutmarks_around_form_reportlab(
+                    c,
+                    x_pt + bleed_pt,
+                    y_pt + bleed_pt,
+                    w_trim_pt,
+                    h_trim_pt,
+                    bleed_mm,
+                )
+
+            _bbox_add(bbox, x_pt, y_pt, x_pt + w_total_pt, y_pt + h_total_pt)
+
+        resumen.append(
+            {
+                "archivo": spec.get("filename")
+                or getattr(file_storage, "filename", f"file_{idx+1}.pdf"),
+                "reps_pedidas": reps,
+                "reps_montadas": len(posiciones),
+                "pliego": f"{pliego_w}x{pliego_h} mm",
+            }
+        )
+
         tmp_paths.append(tmp_path)
 
-    output_path = os.path.join("output", "pliego_offset_pro.pdf")
-    montar_pliego_offset_inteligente(
-        diseños,
-        pro_config.get("ancho_pliego", 0),
-        pro_config.get("alto_pliego", 0),
-        separacion=pro_config.get("separacion", 4),
-        sangrado=0.0,
-        espaciado_horizontal=pro_config.get("espaciado_horizontal", 0),
-        espaciado_vertical=pro_config.get("espaciado_vertical", 0),
-        margen_izq=pro_config.get("margen_izq", 10),
-        margen_der=pro_config.get("margen_der", 10),
-        margen_sup=pro_config.get("margen_sup", 10),
-        margen_inf=pro_config.get("margen_inf", 10),
-        cutmarks_por_forma=pro_config.get("cutmarks_global", False),
-        export_area_util=pro_config.get("export_area_util", False),
-        output_path=output_path,
-    )
+    c.save()
 
     for p in tmp_paths:
         try:
@@ -66,4 +224,8 @@ def montar_pliego_offset_personalizado(specs: List[Dict], pro_config: Dict) -> s
         except OSError:
             pass
 
-    return output_path
+    if export_area_util and bbox[0] is not None:
+        recortar_pdf_a_bbox(output_path, output_path, [bbox])
+
+    return output_path, resumen
+

--- a/tests/test_montaje_offset_personalizado.py
+++ b/tests/test_montaje_offset_personalizado.py
@@ -1,0 +1,76 @@
+import io
+from pathlib import Path
+import pytest
+from reportlab.pdfgen import canvas
+from reportlab.lib.units import mm
+import fitz
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from montaje_offset_personalizado import montar_pliego_offset_personalizado
+
+
+def _crear_pdf_buffer(ancho_mm, alto_mm):
+    buf = io.BytesIO()
+    c = canvas.Canvas(buf, pagesize=(ancho_mm * mm, alto_mm * mm))
+    c.drawString(10, 10, "test")
+    c.save()
+    buf.seek(0)
+    return buf
+
+
+def test_montaje_pro_valido(tmp_path):
+    pdf_buf = _crear_pdf_buffer(50, 50)
+    specs = [{
+        "file": pdf_buf,
+        "filename": "test.pdf",
+        "reps": 4,
+        "rotate": False,
+        "bleed_mm": 0,
+        "cutmarks": False,
+        "align": "left",
+    }]
+    pro_config = {
+        "pliego_w_mm": 200,
+        "pliego_h_mm": 200,
+        "margen_izq_mm": 10,
+        "margen_der_mm": 10,
+        "margen_sup_mm": 10,
+        "margen_inf_mm": 10,
+        "sep_h_mm": 5,
+        "sep_v_mm": 5,
+        "export_area_util": False,
+        "preview": False,
+    }
+    output_path, resumen = montar_pliego_offset_personalizado(specs, pro_config)
+    assert Path(output_path).exists()
+    doc = fitz.open(output_path)
+    assert len(doc) == 1
+    doc.close()
+    assert resumen[0]["reps_montadas"] == 4
+
+
+def test_montaje_pro_error_si_no_caben(tmp_path):
+    pdf_buf = _crear_pdf_buffer(50, 50)
+    specs = [{
+        "file": pdf_buf,
+        "filename": "test.pdf",
+        "reps": 20,
+        "rotate": False,
+        "bleed_mm": 0,
+        "cutmarks": False,
+        "align": "left",
+    }]
+    pro_config = {
+        "pliego_w_mm": 100,
+        "pliego_h_mm": 100,
+        "margen_izq_mm": 10,
+        "margen_der_mm": 10,
+        "margen_sup_mm": 10,
+        "margen_inf_mm": 10,
+        "sep_h_mm": 5,
+        "sep_v_mm": 5,
+        "export_area_util": False,
+        "preview": False,
+    }
+    with pytest.raises(ValueError):
+        montar_pliego_offset_personalizado(specs, pro_config)


### PR DESCRIPTION
## Summary
- add independent PRO offset montage supporting per-file bleed, rotation, alignment, cut marks and preview
- forward `pro_*` parameters through routing to the new custom engine
- cover PRO mode with tests for successful layout and overfill error

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68986800e9bc8322a4f0a1b47537ccc8