### PR TITLE
feat: add manual editing mode for offset layout

### DIFF
--- a/static/js/manual_editor.js
+++ b/static/js/manual_editor.js
@@ -1,0 +1,170 @@
+/**
+ * Editor manual para Montaje Offset Inteligente.
+ * Permite mover y rotar formas sobre el pliego.
+ */
+
+(function () {
+  const btnMode = document.getElementById("btn-manual-mode");
+  const editor = document.getElementById("manual-editor");
+  const overlay = document.getElementById("overlay");
+  const ctx = overlay.getContext("2d");
+  const previewBg = document.getElementById("preview-bg");
+  const manualJson = document.getElementById("manual_json");
+  const btnApply = document.getElementById("btn-manual-apply");
+  const gridInput = document.getElementById("grid_mm");
+  const snapOn = document.getElementById("snap_on");
+  const cursorLbl = document.getElementById("cursor_mm");
+
+  if (!btnMode || !editor) return;
+
+  let boxes = [];
+  let sheet = { w_mm: 0, h_mm: 0 };
+  let sangrado = 0;
+  let scale = 1;
+  let selected = null;
+
+  function mmToPx(mm) {
+    return mm * scale;
+  }
+
+  function pxToMm(px) {
+    return px / scale;
+  }
+
+  function rectScreen(b) {
+    const w = (b.rot ? b.h_mm_trim : b.w_mm_trim) + 2 * sangrado;
+    const h = (b.rot ? b.w_mm_trim : b.h_mm_trim) + 2 * sangrado;
+    return {
+      x: mmToPx(b.x_mm),
+      y: mmToPx(sheet.h_mm - b.y_mm - h),
+      w: mmToPx(w),
+      h: mmToPx(h),
+      w_mm: w,
+      h_mm: h,
+    };
+  }
+
+  function render() {
+    if (!ctx) return;
+    ctx.clearRect(0, 0, overlay.width, overlay.height);
+    boxes.forEach((b) => {
+      const r = rectScreen(b);
+      ctx.save();
+      ctx.strokeStyle = "red";
+      ctx.lineWidth = 1;
+      ctx.strokeRect(r.x, r.y, r.w, r.h);
+      ctx.restore();
+    });
+  }
+
+  function loadState(data) {
+    sangrado = data.sangrado_mm || 0;
+    sheet = data.sheet_mm || sheet;
+    boxes = (data.positions || []).map((p, idx) => ({
+      file_idx: p.file_idx ?? idx,
+      x_mm: p.x_mm,
+      y_mm: p.y_mm,
+      w_mm_trim: p.w_mm,
+      h_mm_trim: p.h_mm,
+      rot: p.rotado || false,
+    }));
+    if (data.preview_url) previewBg.src = data.preview_url;
+    previewBg.onload = () => {
+      scale = previewBg.width / sheet.w_mm;
+      overlay.width = previewBg.width;
+      overlay.height = previewBg.height;
+      render();
+    };
+  }
+
+  function mouseToMm(evt) {
+    const rect = overlay.getBoundingClientRect();
+    const x = evt.clientX - rect.left;
+    const y = evt.clientY - rect.top;
+    return { x: pxToMm(x), y: pxToMm(y) };
+  }
+
+  overlay.addEventListener("mousemove", (e) => {
+    const m = mouseToMm(e);
+    cursorLbl.textContent = `${m.x.toFixed(1)} , ${m.y.toFixed(1)} mm`;
+    if (!selected) return;
+    const grid = parseFloat(gridInput.value) || 1;
+    const totalH = rectScreen(selected.box).h_mm;
+    let nx = m.x - selected.dx;
+    let nyTop = m.y - selected.dy;
+    if (snapOn.checked) {
+      nx = Math.round(nx / grid) * grid;
+      nyTop = Math.round(nyTop / grid) * grid;
+    }
+    selected.box.x_mm = nx;
+    selected.box.y_mm = sheet.h_mm - nyTop - totalH;
+    render();
+  });
+
+  overlay.addEventListener("mousedown", (e) => {
+    const m = mouseToMm(e);
+    selected = null;
+    for (const b of boxes) {
+      const r = rectScreen(b);
+      if (
+        m.x >= pxToMm(r.x) &&
+        m.x <= pxToMm(r.x + r.w) &&
+        m.y >= pxToMm(r.y) &&
+        m.y <= pxToMm(r.y + r.h)
+      ) {
+        selected = {
+          box: b,
+          dx: m.x - b.x_mm,
+          dy: m.y - (sheet.h_mm - b.y_mm - r.h_mm),
+        };
+        break;
+      }
+    }
+  });
+
+  window.addEventListener("mouseup", () => (selected = null));
+
+  window.addEventListener("keydown", (e) => {
+    if (e.key.toLowerCase() === "r" && selected) {
+      selected.box.rot = !selected.box.rot;
+      render();
+    }
+  });
+
+  btnMode.addEventListener("click", () => {
+    editor.style.display = editor.style.display === "none" ? "block" : "none";
+  });
+
+  btnApply.addEventListener("click", () => {
+    const payload = {
+      sheet: { w_mm: sheet.w_mm, h_mm: sheet.h_mm },
+      sangrado_mm: sangrado,
+      posiciones: boxes.map((b) => ({
+        file_idx: b.file_idx,
+        x_mm: b.x_mm,
+        y_mm: b.y_mm,
+        w_mm: b.w_mm_trim,
+        h_mm: b.h_mm_trim,
+        rot: b.rot,
+      })),
+      opciones: {},
+    };
+    manualJson.value = JSON.stringify(payload);
+    fetch("/api/manual/preview", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    })
+      .then((r) => r.json())
+      .then((resp) => {
+        if (resp.preview_url) {
+          loadState(resp);
+        }
+      })
+      .catch((err) => console.error(err));
+  });
+
+  // Expose loader
+  window.manualEditorLoad = loadState;
+})();
+

--- a/templates/montaje_offset_inteligente.html
+++ b/templates/montaje_offset_inteligente.html
@@ -13,6 +13,7 @@
   <div id="form-std">
   <form id="frm-inteligente" method="POST" enctype="multipart/form-data">
     <input type="hidden" name="accion" id="accion" value="generar">
+    <input type="hidden" name="manual_json" id="manual_json">
     <label>Subir de 1 a 5 archivos PDF:</label>
     <input type="file" name="archivos[]" accept=".pdf" multiple required>
     <div id="repeticiones-container"></div>
@@ -147,6 +148,8 @@
       <button type="button" class="btn btn-secondary" id="btn-preview">Vista previa (150 dpi)</button>
       <button type="submit" class="btn btn-primary" id="btn-generar">Generar PDF</button>
       <button id="btn-reset" type="reset">Actualizar formulario</button>
+      <button type="button" id="btn-manual-mode">Entrar a edición manual</button>
+      <label style="display:flex; align-items:center; gap:4px;"><input type="checkbox" id="manual-toggle"> Edición manual</label>
     </div>
   </form>
 
@@ -165,6 +168,19 @@
     {% endif %}
   </div>
   {% endif %}
+
+  <div id="manual-editor" style="display:none;">
+    <div class="toolbar">
+      <button id="btn-manual-apply">Aplicar edición manual</button>
+      <label>Grid (mm): <input id="grid_mm" type="number" step="0.5" value="1"></label>
+      <label><input type="checkbox" id="snap_on" checked> Snap</label>
+      <span id="cursor_mm"></span>
+    </div>
+    <div class="stage" id="manual-stage" style="position:relative; overflow:auto;">
+      <img id="preview-bg" src="{{ preview_url or '' }}" alt="preview" />
+      <canvas id="overlay" width="0" height="0" style="position:absolute; left:0; top:0;"></canvas>
+    </div>
+  </div>
 
   <script>
     document.querySelector('select[name="pliego"]').addEventListener('change', function() {
@@ -338,5 +354,6 @@
     });
   })();
   </script>
+  <script src="{{ url_for('static', filename='js/manual_editor.js') }}"></script>
 </body>
 </html>

--- a/tests/test_montaje_offset_inteligente.py
+++ b/tests/test_montaje_offset_inteligente.py
@@ -254,3 +254,36 @@ def test_montar_pliego_offset_cache(monkeypatch, tmp_path):
     )
     assert calls["count"] == 2
     assert output.exists()
+
+
+def test_manual_positions_preview_and_pdf(tmp_path):
+    pdf = _crear_pdf_temporal(20, 10)
+    posiciones = [
+        {"file_idx": 0, "x_mm": 10, "y_mm": 20, "w_mm": 20, "h_mm": 10, "rot": False}
+    ]
+    prev = tmp_path / "prev.png"
+    res = montaje_offset_inteligente.montar_pliego_offset_inteligente(
+        [(pdf, 1)],
+        100,
+        100,
+        sangrado=0,
+        estrategia="manual",
+        posiciones_manual=posiciones,
+        preview_path=str(prev),
+        devolver_posiciones=True,
+        centrar=False,
+    )
+    assert prev.exists()
+    assert res["positions"][0]["x_mm"] == pytest.approx(10.0)
+    out = tmp_path / "out.pdf"
+    montaje_offset_inteligente.montar_pliego_offset_inteligente(
+        [(pdf, 1)],
+        100,
+        100,
+        sangrado=0,
+        estrategia="manual",
+        posiciones_manual=posiciones,
+        output_path=str(out),
+        centrar=False,
+    )
+    assert out.exists()


### PR DESCRIPTION
## Summary
- add manual editing branch to offset layout engine and return normalized positions
- expose REST endpoints for manual preview and PDF generation
- add UI and JS editor for interactive manual positioning
- cover manual branch with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afa1c5e37c8322a2029b883da292df