### PR TITLE
Add manual editor preview integration and PDF export

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -378,84 +378,55 @@ def montaje_offset_inteligente_view():
             preview_path = os.path.join(
                 previews_dir, f"offset_inteligente_{job_id}.png"
             )
-            try:
-                png_bytes, resumen_html = montar_pliego_offset_inteligente(
-                    diseños,
-                    ancho_pliego,
-                    alto_pliego,
-                    separacion=params["separacion"],
-                    sangrado=params["sangrado"],
-                    usar_trimbox=params["usar_trimbox"],
-                    ordenar_tamano=params["ordenar_tamano"],
-                    alinear_filas=params["alinear_filas"],
-                    preferir_horizontal=params["preferir_horizontal"],
-                    centrar=params["centrar"],
-                    debug_grilla=params["debug_grilla"],
-                    espaciado_horizontal=params["espaciado_horizontal"],
-                    espaciado_vertical=params["espaciado_vertical"],
-                    margen_izq=params["margen_izq"],
-                    margen_der=params["margen_der"],
-                    margen_sup=params["margen_sup"],
-                    margen_inf=params["margen_inf"],
-                    estrategia=params["estrategia"],
-                    filas=params["filas"],
-                    columnas=params["columnas"],
-                    celda_ancho=params["celda_ancho"],
-                    celda_alto=params["celda_alto"],
-                    pinza_mm=params["pinza_mm"],
-                    lateral_mm=params["lateral_mm"],
-                    marcas_registro=params["marcas_registro"],
-                    marcas_corte=params["marcas_corte"],
-                    cutmarks_por_forma=params["cutmarks_por_forma"],
-                    preview_only=True,
-                    preview_dpi=150,
-                    **opciones_extra,
-                )
-            except TypeError:
-                png_bytes, resumen_html = montar_pliego_offset_inteligente(
-                    diseños,
-                    ancho_pliego,
-                    alto_pliego,
-                    separacion=params["separacion"],
-                    sangrado=params["sangrado"],
-                    usar_trimbox=params["usar_trimbox"],
-                    ordenar_tamano=params["ordenar_tamano"],
-                    alinear_filas=params["alinear_filas"],
-                    preferir_horizontal=params["preferir_horizontal"],
-                    centrar=params["centrar"],
-                    debug_grilla=params["debug_grilla"],
-                    espaciado_horizontal=params["espaciado_horizontal"],
-                    espaciado_vertical=params["espaciado_vertical"],
-                    margen_izq=params["margen_izq"],
-                    margen_der=params["margen_der"],
-                    margen_sup=params["margen_sup"],
-                    margen_inf=params["margen_inf"],
-                    estrategia=params["estrategia"],
-                    filas=params["filas"],
-                    columnas=params["columnas"],
-                    celda_ancho=params["celda_ancho"],
-                    celda_alto=params["celda_alto"],
-                    pinza_mm=params["pinza_mm"],
-                    lateral_mm=params["lateral_mm"],
-                    marcas_registro=params["marcas_registro"],
-                    marcas_corte=params["marcas_corte"],
-                    cutmarks_por_forma=params["cutmarks_por_forma"],
-                    preview_only=True,
-                    **opciones_extra,
-                )
-            from PIL import Image
-            image = Image.open(io.BytesIO(png_bytes if isinstance(png_bytes, bytes) else png_bytes))
-            image.save(preview_path, format="PNG")
-            image.close()
+            # NUEVO: generamos preview real y pedimos posiciones/sheet
+            res = montar_pliego_offset_inteligente(
+                diseños,
+                ancho_pliego,
+                alto_pliego,
+                separacion=params["separacion"],
+                sangrado=params["sangrado"],
+                usar_trimbox=params["usar_trimbox"],
+                ordenar_tamano=params["ordenar_tamano"],
+                alinear_filas=params["alinear_filas"],
+                preferir_horizontal=params["preferir_horizontal"],
+                centrar=params["centrar"],
+                debug_grilla=params["debug_grilla"],
+                espaciado_horizontal=params["espaciado_horizontal"],
+                espaciado_vertical=params["espaciado_vertical"],
+                margen_izq=params["margen_izq"],
+                margen_der=params["margen_der"],
+                margen_sup=params["margen_sup"],
+                margen_inf=params["margen_inf"],
+                estrategia=params["estrategia"],
+                filas=params["filas"],
+                columnas=params["columnas"],
+                celda_ancho=params["celda_ancho"],
+                celda_alto=params["celda_alto"],
+                pinza_mm=params["pinza_mm"],
+                lateral_mm=params["lateral_mm"],
+                marcas_registro=params["marcas_registro"],
+                marcas_corte=params["marcas_corte"],
+                cutmarks_por_forma=params["cutmarks_por_forma"],
+                preview_path=preview_path,          # << importante
+                devolver_posiciones=True,           # << importante
+                preview_dpi=150,
+                preview_only=False,
+                **opciones_extra,
+            )
+
             rel_path = os.path.relpath(preview_path, current_app.static_folder).replace(
                 "\\", "/"
             )
             preview_url = url_for("static", filename=rel_path)
+
             return render_template(
                 "montaje_offset_inteligente.html",
                 resultado=None,
                 preview_url=preview_url,
-                resumen_html=resumen_html,
+                resumen_html=res.get("resumen_html"),
+                positions=res.get("positions"),
+                sheet_mm=res.get("sheet_mm"),
+                sangrado_mm=params["sangrado"],
             )
 
         output_path = os.path.join("output", "pliego_offset_inteligente.pdf")

--- a/static/js/manual_editor.js
+++ b/static/js/manual_editor.js
@@ -11,6 +11,7 @@
   const previewBg = document.getElementById("preview-bg");
   const manualJson = document.getElementById("manual_json");
   const btnApply = document.getElementById("btn-manual-apply");
+  const btnGen = document.getElementById("btn-manual-generate");
   const gridInput = document.getElementById("grid_mm");
   const snapOn = document.getElementById("snap_on");
   const cursorLbl = document.getElementById("cursor_mm");
@@ -162,6 +163,37 @@
         }
       })
       .catch((err) => console.error(err));
+  });
+
+  btnGen?.addEventListener("click", () => {
+    const payload = {
+      sheet: { w_mm: sheet.w_mm, h_mm: sheet.h_mm },
+      sangrado_mm: sangrado,
+      posiciones: boxes.map(b => ({
+        file_idx: b.file_idx,
+        x_mm: b.x_mm,
+        y_mm: b.y_mm,
+        w_mm: b.w_mm_trim,
+        h_mm: b.h_mm_trim,
+        rot: b.rot,
+      })),
+      opciones: {}
+    };
+
+    fetch("/api/manual/impose", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    })
+      .then(r => r.json())
+      .then(resp => {
+        if (resp.pdf_url) {
+          window.location.href = resp.pdf_url;
+        } else {
+          alert("No se pudo generar el PDF manual.");
+        }
+      })
+      .catch(err => console.error(err));
   });
 
   // Expose loader

--- a/templates/montaje_offset_inteligente.html
+++ b/templates/montaje_offset_inteligente.html
@@ -13,7 +13,6 @@
   <div id="form-std">
   <form id="frm-inteligente" method="POST" enctype="multipart/form-data">
     <input type="hidden" name="accion" id="accion" value="generar">
-    <input type="hidden" name="manual_json" id="manual_json">
     <label>Subir de 1 a 5 archivos PDF:</label>
     <input type="file" name="archivos[]" accept=".pdf" multiple required>
     <div id="repeticiones-container"></div>
@@ -172,6 +171,9 @@
   <div id="manual-editor" style="display:none;">
     <div class="toolbar">
       <button id="btn-manual-apply">Aplicar edición manual</button>
+      <button id="btn-manual-generate" type="button" style="margin-left:8px;">
+        Generar PDF (manual)
+      </button>
       <label>Grid (mm): <input id="grid_mm" type="number" step="0.5" value="1"></label>
       <label><input type="checkbox" id="snap_on" checked> Snap</label>
       <span id="cursor_mm"></span>
@@ -180,6 +182,7 @@
       <img id="preview-bg" src="{{ preview_url or '' }}" alt="preview" />
       <canvas id="overlay" width="0" height="0" style="position:absolute; left:0; top:0;"></canvas>
     </div>
+    <input type="hidden" id="manual_json" name="manual_json">
   </div>
 
   <script>
@@ -354,6 +357,26 @@
     });
   })();
   </script>
+  {% if preview_url %}
+  <script>
+    window.__sheetMm    = {{ sheet_mm|tojson|safe }};
+    window.__positions  = {{ positions|tojson|safe }};
+    window.__sangradoMm = {{ sangrado_mm|default(0) }};
+    window.__previewUrl = "{{ preview_url }}";
+  </script>
+  {% endif %}
   <script src="{{ url_for('static', filename='js/manual_editor.js') }}"></script>
+  {% if preview_url %}
+  <script>
+    if (window.manualEditorLoad) {
+      window.manualEditorLoad({
+        sheet_mm: window.__sheetMm,
+        positions: window.__positions,
+        sangrado_mm: window.__sangradoMm,
+        preview_url: window.__previewUrl
+      });
+    }
+  </script>
+  {% endif %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Generate preview, positions and sheet data for manual editor in `montaje_offset_inteligente`
- Inject manual editor assets and controls into template with auto-loading of preview state
- Allow manual editor to export a PDF using `/api/manual/impose`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afad80b3ac8322b1e106fe5476edde