### PR TITLE
feat: improve manual editor with zoom and drag limits

### DIFF
--- a/static/js/manual_editor.js
+++ b/static/js/manual_editor.js
@@ -1,202 +1,299 @@
 /**
- * Editor manual para Montaje Offset Inteligente.
- * Permite mover y rotar formas sobre el pliego.
+ * Editor manual — fit width + zoom + NaN fix + límites de arrastre.
  */
-
 (function () {
-  const btnMode = document.getElementById("btn-manual-mode");
-  const editor = document.getElementById("manual-editor");
-  const overlay = document.getElementById("overlay");
-  const ctx = overlay.getContext("2d");
-  const previewBg = document.getElementById("preview-bg");
-  const manualJson = document.getElementById("manual_json");
-  const btnApply = document.getElementById("btn-manual-apply");
-  const btnGen = document.getElementById("btn-manual-generate");
-  const gridInput = document.getElementById("grid_mm");
-  const snapOn = document.getElementById("snap_on");
-  const cursorLbl = document.getElementById("cursor_mm");
+  const stage    = document.getElementById('manual-stage');
+  const viewport = document.getElementById('viewport');
+  const img      = document.getElementById('preview-bg');
+  const overlay  = document.getElementById('overlay');
 
-  if (!btnMode || !editor) return;
+  const btnMode  = document.getElementById('btn-manual-mode');
+  const btnApply = document.getElementById('btn-manual-apply');
+  const btnGen   = document.getElementById('btn-manual-generate');
 
-  let boxes = [];
-  let sheet = { w_mm: 0, h_mm: 0 };
-  let sangrado = 0;
-  let scale = 1;
-  let selected = null;
+  const gridInput = document.getElementById('grid_mm');
+  const snapChk   = document.getElementById('snap_on');
+  const cursorMM  = document.getElementById('cursor_mm');
 
-  function mmToPx(mm) {
-    return mm * scale;
-  }
+  const zoomRange = document.getElementById('zoom_range');
+  const zoomLabel = document.getElementById('zoom_label');
+  const fitWidth  = document.getElementById('fit_width');
+  const fitPage   = document.getElementById('fit_page');
 
-  function pxToMm(px) {
-    return px / scale;
-  }
+  const manualJson = document.getElementById('manual_json');
 
-  function rectScreen(b) {
-    const w = (b.rot ? b.h_mm_trim : b.w_mm_trim) + 2 * sangrado;
-    const h = (b.rot ? b.w_mm_trim : b.h_mm_trim) + 2 * sangrado;
-    return {
-      x: mmToPx(b.x_mm),
-      y: mmToPx(sheet.h_mm - b.y_mm - h),
-      w: mmToPx(w),
-      h: mmToPx(h),
-      w_mm: w,
-      h_mm: h,
-    };
-  }
+  if (!overlay || !img || !stage || !viewport) return;
 
-  function render() {
-    if (!ctx) return;
-    ctx.clearRect(0, 0, overlay.width, overlay.height);
-    boxes.forEach((b) => {
-      const r = rectScreen(b);
-      ctx.save();
-      ctx.strokeStyle = "red";
-      ctx.lineWidth = 1;
-      ctx.strokeRect(r.x, r.y, r.w, r.h);
-      ctx.restore();
+  const toNum = (v, def=0) => {
+    const n = Number(v);
+    return Number.isFinite(n) ? n : def;
+  };
+
+  const state = {
+    sheet:  { w: 0, h: 0 },        // mm
+    sangrado: toNum(window.__sangradoMm, 0),
+    baseScale: 1,                  // px/mm con fit width
+    zoom: 1,                       // 1 = 100%
+    boxes: [],
+    selectedId: null,
+    drag: null,
+  };
+
+  const mmToPx = (mm) => mm * state.baseScale * state.zoom;
+  const pxToMm = (px) => px / (state.baseScale * state.zoom);
+
+  // Conversión BL <-> TL (top-left para pintar)
+  const blToTl = (x_bl, y_bl, h_total) => ({ x: x_bl, y: state.sheet.h - y_bl - h_total });
+  const tlToBl = (x_tl, y_tl, h_total) => ({ x: x_tl, y: state.sheet.h - y_tl - h_total });
+
+  // Construcción de cajas desde positions normalizadas
+  function buildBoxes(positions) {
+    return (positions || []).map((p, i) => {
+      const rot = !!(p.rotado || p.rot);
+      const wT  = toNum(p.w_mm, 0), hT = toNum(p.h_mm, 0);
+      const W   = wT + 2*state.sangrado;
+      const H   = hT + 2*state.sangrado;
+      const tl  = blToTl(toNum(p.x_mm,0), toNum(p.y_mm,0), H);
+      return {
+        id: i,
+        archivo: p.archivo ?? null,
+        file_idx: Number.isFinite(p.file_idx) ? p.file_idx : i,
+        rot,
+        w_trim_mm: wT,
+        h_trim_mm: hT,
+        total_w_mm: rot ? H : W,   // al rotar intercambiamos percepción de W/H
+        total_h_mm: rot ? W : H,
+        x_tl_mm: tl.x,
+        y_tl_mm: tl.y,
+      };
     });
   }
 
-  function loadState(data) {
-    sangrado = data.sangrado_mm || 0;
-    sheet = data.sheet_mm || sheet;
-    boxes = (data.positions || []).map((p, idx) => ({
-      file_idx: p.file_idx ?? idx,
-      x_mm: p.x_mm,
-      y_mm: p.y_mm,
-      w_mm_trim: p.w_mm,
-      h_mm_trim: p.h_mm,
-      rot: p.rotado || false,
-    }));
-    if (data.preview_url) previewBg.src = data.preview_url;
-    previewBg.onload = () => {
-      scale = previewBg.width / sheet.w_mm;
-      overlay.width = previewBg.width;
-      overlay.height = previewBg.height;
-      render();
-    };
+  // Escalado base: encajar ancho de la imagen al ancho visible
+  function syncBaseScale() {
+    const visibleW = img.clientWidth || img.getBoundingClientRect().width || img.naturalWidth || 1;
+    state.baseScale = visibleW / (state.sheet.w || 1);
+    overlay.width  = Math.round(visibleW);
+    overlay.height = Math.round(state.sheet.h * state.baseScale);
   }
 
-  function mouseToMm(evt) {
-    const rect = overlay.getBoundingClientRect();
-    const x = evt.clientX - rect.left;
-    const y = evt.clientY - rect.top;
-    return { x: pxToMm(x), y: pxToMm(y) };
+  // Zoom con CSS transform (escala el viewport completo)
+  function setZoom(percent) {
+    const z = Math.max(0.1, Math.min(2.0, percent / 100));
+    state.zoom = z;
+    viewport.style.transform = `scale(${state.zoom})`;
+    if (zoomLabel) zoomLabel.textContent = `${Math.round(percent)}%`;
+    repaint();
   }
 
-  overlay.addEventListener("mousemove", (e) => {
-    const m = mouseToMm(e);
-    cursorLbl.textContent = `${m.x.toFixed(1)} , ${m.y.toFixed(1)} mm`;
-    if (!selected) return;
-    const grid = parseFloat(gridInput.value) || 1;
-    const totalH = rectScreen(selected.box).h_mm;
-    let nx = m.x - selected.dx;
-    let nyTop = m.y - selected.dy;
-    if (snapOn.checked) {
-      nx = Math.round(nx / grid) * grid;
-      nyTop = Math.round(nyTop / grid) * grid;
+  function fitToWidth() {
+    setZoom(100);
+    repaint();
+  }
+
+  function fitToPage() {
+    const visibleW = img.clientWidth || img.getBoundingClientRect().width || 1;
+    const baseHpx  = state.sheet.h * (visibleW / (state.sheet.w || 1));
+    const stageH   = stage.clientHeight || 1;
+    const ratio    = stageH / baseHpx;
+    setZoom(Math.max(10, Math.min(200, Math.floor(ratio * 100))));
+  }
+
+  const ctx = overlay.getContext('2d');
+
+  function drawGrid() {
+    const gmm = Math.max(0.1, toNum(gridInput.value, 1));
+    const step = mmToPx(gmm);
+    const W = overlay.width, H = overlay.height;
+    ctx.save();
+    ctx.lineWidth = 1;
+    ctx.strokeStyle = 'rgba(0,0,0,0.08)';
+    ctx.beginPath();
+    for (let x = 0; x <= W; x += step) { ctx.moveTo(x, 0); ctx.lineTo(x, H); }
+    for (let y = 0; y <= H; y += step) { ctx.moveTo(0, y); ctx.lineTo(W, y); }
+    ctx.stroke();
+    ctx.restore();
+  }
+
+  function drawBoxes() {
+    for (const b of state.boxes) {
+      const x = mmToPx(b.x_tl_mm), y = mmToPx(b.y_tl_mm);
+      const w = mmToPx(b.total_w_mm), h = mmToPx(b.total_h_mm);
+
+      ctx.save();
+      ctx.fillStyle = 'rgba(0,0,0,0.04)'; ctx.fillRect(x+2, y+2, w, h);
+      const sel = (state.selectedId === b.id);
+      ctx.lineWidth = sel ? 2 : 1;
+      ctx.strokeStyle = sel ? '#0ea5e9' : '#111';
+      ctx.fillStyle = 'rgba(14,165,233,0.08)';
+      ctx.fillRect(x, y, w, h); ctx.strokeRect(x, y, w, h);
+
+      // Área trim (interior)
+      const trimX = x + mmToPx(state.sangrado);
+      const trimY = y + mmToPx(state.sangrado);
+      const trimW = mmToPx(b.w_trim_mm);
+      const trimH = mmToPx(b.h_trim_mm);
+      ctx.setLineDash([4,3]); ctx.strokeStyle='rgba(0,0,0,0.6)';
+      ctx.strokeRect(trimX, trimY, trimW, trimH); ctx.setLineDash([]);
+
+      ctx.fillStyle = '#111'; ctx.font = '12px sans-serif';
+      const label = (b.archivo ? b.archivo.split('/').pop() : `PDF ${b.file_idx+1}`) + (b.rot ? ' • R90' : '');
+      ctx.fillText(label, x + 6, y + 16);
+      ctx.restore();
     }
-    selected.box.x_mm = nx;
-    selected.box.y_mm = sheet.h_mm - nyTop - totalH;
-    render();
+  }
+
+  function repaint() {
+    ctx.clearRect(0,0,overlay.width, overlay.height);
+    if (snapChk?.checked) drawGrid();
+    drawBoxes();
+  }
+
+  function hitTest(px, py) {
+    for (let i = state.boxes.length-1; i >= 0; i--) {
+      const b = state.boxes[i];
+      const x = mmToPx(b.x_tl_mm), y = mmToPx(b.y_tl_mm);
+      const w = mmToPx(b.total_w_mm), h = mmToPx(b.total_h_mm);
+      if (px>=x && px<=x+w && py>=y && py<=y+h) return b.id;
+    }
+    return null;
+  }
+
+  overlay.addEventListener('mousemove', (e) => {
+    const r = overlay.getBoundingClientRect();
+    const px = e.clientX - r.left, py = e.clientY - r.top;
+    const mmX = pxToMm(px), mmY = pxToMm(py);
+    if (cursorMM && Number.isFinite(mmX) && Number.isFinite(mmY)) {
+      cursorMM.textContent = `${mmX.toFixed(1)} , ${mmY.toFixed(1)} mm`;
+    }
+
+    if (!state.drag) return;
+    const b = state.boxes.find(x => x.id === state.drag.id);
+    if (!b) return;
+
+    let nx = state.drag.startTl.x + pxToMm(px - state.drag.startPx.x);
+    let ny = state.drag.startTl.y + pxToMm(py - state.drag.startPx.y);
+
+    if (snapChk?.checked) {
+      const g = Math.max(0.1, toNum(gridInput.value, 1));
+      nx = Math.round(nx / g) * g;
+      ny = Math.round(ny / g) * g;
+    }
+
+    // clamp a bordes
+    nx = Math.max(0, Math.min(nx, state.sheet.w - b.total_w_mm));
+    ny = Math.max(0, Math.min(ny, state.sheet.h - b.total_h_mm));
+
+    b.x_tl_mm = nx; b.y_tl_mm = ny;
+    repaint();
   });
 
-  overlay.addEventListener("mousedown", (e) => {
-    const m = mouseToMm(e);
-    selected = null;
-    for (const b of boxes) {
-      const r = rectScreen(b);
-      if (
-        m.x >= pxToMm(r.x) &&
-        m.x <= pxToMm(r.x + r.w) &&
-        m.y >= pxToMm(r.y) &&
-        m.y <= pxToMm(r.y + r.h)
-      ) {
-        selected = {
-          box: b,
-          dx: m.x - b.x_mm,
-          dy: m.y - (sheet.h_mm - b.y_mm - r.h_mm),
-        };
-        break;
+  overlay.addEventListener('mousedown', (e) => {
+    const r = overlay.getBoundingClientRect();
+    const px = e.clientX - r.left, py = e.clientY - r.top;
+    const id = hitTest(px, py);
+    state.selectedId = id; repaint();
+
+    if (id != null) {
+      const b = state.boxes.find(x => x.id === id);
+      state.drag = {
+        id,
+        startPx: { x:px, y:py },
+        startTl: { x:b.x_tl_mm, y:b.y_tl_mm },
+      };
+    }
+  });
+
+  window.addEventListener('mouseup', () => { state.drag = null; });
+
+  window.addEventListener('keydown', (e) => {
+    if (!state.selectedId && state.selectedId !== 0) return;
+    const b = state.boxes.find(x => x.id === state.selectedId);
+    if (!b) return;
+    if (e.key.toLowerCase() === 'r') {
+      b.rot = !b.rot;
+      // intercambiar trim y totales
+      [b.w_trim_mm, b.h_trim_mm] = [b.h_trim_mm, b.w_trim_mm];
+      [b.total_w_mm, b.total_h_mm] = [b.total_h_mm, b.total_w_mm];
+      // re-clamp
+      b.x_tl_mm = Math.min(b.x_tl_mm, state.sheet.w - b.total_w_mm);
+      b.y_tl_mm = Math.min(b.y_tl_mm, state.sheet.h - b.total_h_mm);
+      repaint();
+    }
+  });
+
+  function buildPayload() {
+    const posiciones = state.boxes.map(b => {
+      const bl = tlToBl(b.x_tl_mm, b.y_tl_mm, b.total_h_mm);
+      return {
+        file_idx: b.file_idx,
+        x_mm: Number(bl.x.toFixed(3)),
+        y_mm: Number(bl.y.toFixed(3)),
+        w_mm: Number(b.w_trim_mm.toFixed(3)),
+        h_mm: Number(b.h_trim_mm.toFixed(3)),
+        rot: !!b.rot
+      };
+    });
+    return { sheet: { w_mm: state.sheet.w, h_mm: state.sheet.h }, sangrado_mm: state.sangrado, posiciones };
+  }
+
+  btnApply?.addEventListener('click', () => {
+    const payload = buildPayload();
+    if (manualJson) manualJson.value = JSON.stringify(payload);
+    fetch('/api/manual/preview', {
+      method:'POST', headers:{'Content-Type':'application/json'},
+      body: JSON.stringify(payload)
+    }).then(r=>r.json()).then(data=>{
+      if (data.preview_url) {
+        img.src = data.preview_url;
+        // recarga posiciones para seguir editando
+        initFromData({ sheet_mm:data.sheet_mm, posiciones:data.positions, sangrado_mm: state.sangrado });
       }
+    }).catch(console.error);
+  });
+
+  btnGen?.addEventListener('click', () => {
+    const payload = buildPayload();
+    fetch('/api/manual/impose', {
+      method:'POST', headers:{'Content-Type':'application/json'},
+      body: JSON.stringify(payload)
+    }).then(r=>r.json()).then(resp=>{
+      if (resp.pdf_url) window.location.href = resp.pdf_url;
+      else alert('No se pudo generar el PDF manual.');
+    }).catch(console.error);
+  });
+
+  function initFromData(opts) {
+    state.sheet = { w: toNum(opts?.sheet_mm?.w, 0), h: toNum(opts?.sheet_mm?.h, 0) };
+    state.sangrado = toNum(opts?.sangrado_mm, state.sangrado);
+    state.boxes = buildBoxes(Array.isArray(opts?.positions) ? opts.positions : []);
+    // (re)calcular escala base y dibujar
+    if (img.complete) {
+      syncBaseScale(); setZoom(toNum(zoomRange?.value, 100)); repaint();
+    } else {
+      img.addEventListener('load', () => { syncBaseScale(); setZoom(toNum(zoomRange?.value, 100)); repaint(); }, { once:true });
     }
+  }
+
+  // Expuesto para el template
+  window.manualEditorLoad = function(opts) {
+    if (opts?.preview_url) img.src = opts.preview_url;
+    initFromData({ sheet_mm:opts?.sheet_mm, posiciones:opts?.positions, sangrado_mm:opts?.sangrado_mm });
+  };
+
+  // Toggle de panel
+  btnMode?.addEventListener('click', () => {
+    const show = (document.getElementById('manual-editor').style.display !== 'block');
+    document.getElementById('manual-editor').style.display = show ? 'block' : 'none';
+    if (show) { syncBaseScale(); setZoom(toNum(zoomRange?.value, 100)); repaint(); }
   });
 
-  window.addEventListener("mouseup", () => (selected = null));
+  // Responder a resize del contenedor
+  const ro = new ResizeObserver(() => { syncBaseScale(); repaint(); });
+  ro.observe(stage);
 
-  window.addEventListener("keydown", (e) => {
-    if (e.key.toLowerCase() === "r" && selected) {
-      selected.box.rot = !selected.box.rot;
-      render();
-    }
-  });
-
-  btnMode.addEventListener("click", () => {
-    editor.style.display = editor.style.display === "none" ? "block" : "none";
-  });
-
-  btnApply.addEventListener("click", () => {
-    const payload = {
-      sheet: { w_mm: sheet.w_mm, h_mm: sheet.h_mm },
-      sangrado_mm: sangrado,
-      posiciones: boxes.map((b) => ({
-        file_idx: b.file_idx,
-        x_mm: b.x_mm,
-        y_mm: b.y_mm,
-        w_mm: b.w_mm_trim,
-        h_mm: b.h_mm_trim,
-        rot: b.rot,
-      })),
-      opciones: {},
-    };
-    manualJson.value = JSON.stringify(payload);
-    fetch("/api/manual/preview", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(payload),
-    })
-      .then((r) => r.json())
-      .then((resp) => {
-        if (resp.preview_url) {
-          loadState(resp);
-        }
-      })
-      .catch((err) => console.error(err));
-  });
-
-  btnGen?.addEventListener("click", () => {
-    const payload = {
-      sheet: { w_mm: sheet.w_mm, h_mm: sheet.h_mm },
-      sangrado_mm: sangrado,
-      posiciones: boxes.map(b => ({
-        file_idx: b.file_idx,
-        x_mm: b.x_mm,
-        y_mm: b.y_mm,
-        w_mm: b.w_mm_trim,
-        h_mm: b.h_mm_trim,
-        rot: b.rot,
-      })),
-      opciones: {}
-    };
-
-    fetch("/api/manual/impose", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(payload),
-    })
-      .then(r => r.json())
-      .then(resp => {
-        if (resp.pdf_url) {
-          window.location.href = resp.pdf_url;
-        } else {
-          alert("No se pudo generar el PDF manual.");
-        }
-      })
-      .catch(err => console.error(err));
-  });
-
-  // Expose loader
-  window.manualEditorLoad = loadState;
+  // Zoom UI
+  zoomRange?.addEventListener('input', () => setZoom(toNum(zoomRange.value, 100)));
+  fitWidth?.addEventListener('click', fitToWidth);
+  fitPage?.addEventListener('click', fitToPage);
 })();
-

--- a/templates/montaje_offset_inteligente.html
+++ b/templates/montaje_offset_inteligente.html
@@ -168,20 +168,38 @@
   </div>
   {% endif %}
 
-  <div id="manual-editor" style="display:none;">
-    <div class="toolbar">
-      <button id="btn-manual-apply">Aplicar edición manual</button>
-      <button id="btn-manual-generate" type="button" style="margin-left:8px;">
-        Generar PDF (manual)
-      </button>
-      <label>Grid (mm): <input id="grid_mm" type="number" step="0.5" value="1"></label>
+  <div id="manual-editor" style="display:none; margin-top:12px;">
+    <div class="toolbar" style="display:flex; gap:12px; align-items:center; flex-wrap:wrap;">
+      <button id="btn-manual-apply" type="button">Aplicar edición manual</button>
+      <button id="btn-manual-generate" type="button">Generar PDF (manual)</button>
+      <label>Grid (mm):
+        <input id="grid_mm" type="number" step="0.5" min="0.1" value="1" style="width:80px;">
+      </label>
       <label><input type="checkbox" id="snap_on" checked> Snap</label>
-      <span id="cursor_mm"></span>
+
+      <!-- NUEVO: controles de zoom -->
+      <label>Zoom:
+        <input id="zoom_range" type="range" min="10" max="200" step="5" value="100">
+        <span id="zoom_label">100%</span>
+      </label>
+      <button id="fit_width" type="button">Ajustar ancho</button>
+      <button id="fit_page" type="button">Ajustar página</button>
+
+      <span id="cursor_mm" style="opacity:.7;"></span>
     </div>
-    <div class="stage" id="manual-stage" style="position:relative; overflow:auto;">
-      <img id="preview-bg" src="{{ preview_url or '' }}" alt="preview" />
-      <canvas id="overlay" width="0" height="0" style="position:absolute; left:0; top:0;"></canvas>
+
+    <!-- Contenedor con altura máxima para que no “rompa” la página -->
+    <div id="manual-stage"
+         style="position:relative; max-width:100%;
+                max-height:70vh; overflow:auto; border:1px solid #ddd; background:#fafafa;">
+      <!-- Viewport escalable (zoom con transform) -->
+      <div id="viewport" style="position:relative; transform-origin: top left;">
+        <img id="preview-bg" src="{{ preview_url or '' }}"
+             style="display:block; width:100%; height:auto;" alt="preview">
+        <canvas id="overlay" style="position:absolute; left:0; top:0; pointer-events:auto;"></canvas>
+      </div>
     </div>
+
     <input type="hidden" id="manual_json" name="manual_json">
   </div>
 
@@ -368,14 +386,12 @@
   <script src="{{ url_for('static', filename='js/manual_editor.js') }}"></script>
   {% if preview_url %}
   <script>
-    if (window.manualEditorLoad) {
-      window.manualEditorLoad({
-        sheet_mm: window.__sheetMm,
-        positions: window.__positions,
-        sangrado_mm: window.__sangradoMm,
-        preview_url: window.__previewUrl
-      });
-    }
+    window.manualEditorLoad && window.manualEditorLoad({
+      sheet_mm:    window.__sheetMm,
+      positions:   window.__positions,
+      sangrado_mm: window.__sangradoMm,
+      preview_url: window.__previewUrl
+    });
   </script>
   {% endif %}
 </body>


### PR DESCRIPTION
## Summary
- add fit-to-width viewport with zoom controls and fit width/page buttons in manual editor
- overhaul manual editor script to handle zoom, drag clamping, rotation reclamping, and cursor NaN fix

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afbdf59efc8322a1f4b24769d64602