### PR TITLE
fix(manual): validar payload, evitar 500 y persistir preview/pdf

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,13 +6,17 @@ from routes import routes_bp
 
 app = Flask(__name__)
 app.config.from_object("config")
-app.config["MAX_CONTENT_LENGTH"] = 32 * 1024 * 1024
+app.config.setdefault("MAX_CONTENT_LENGTH", 32 * 1024 * 1024)
 os.makedirs(os.path.join(app.static_folder, "previews"), exist_ok=True)
+os.makedirs(os.path.join(app.static_folder, "outputs"), exist_ok=True)
 
 
 @app.errorhandler(RequestEntityTooLarge)
 def handle_413(e):
-    return jsonify(ok=False, error="Payload demasiado grande."), 413
+    return jsonify(
+        ok=False,
+        error="Payload demasiado grande. Reduce DPI o cantidad de archivos.",
+    ), 413
 
 
 app.register_blueprint(routes_bp)

--- a/templates/montaje_offset_inteligente.html
+++ b/templates/montaje_offset_inteligente.html
@@ -368,7 +368,7 @@
     window.__positions  = {{ positions|tojson|safe }};
     window.__sangradoMm = {{ sangrado_mm|default(0) }};
     window.__previewUrl = "{{ preview_url }}";
-    window.__manualFiles = {{ files_list|tojson|safe }};
+    window.__manualFiles = {{ files_list|tojson|safe }};   // lista de rutas de PDFs
   </script>
   {% endif %}
   <script src="{{ url_for('static', filename='js/manual_editor.js') }}"></script>


### PR DESCRIPTION
## Summary
- validate manual preview/impose payload and handle errors as JSON
- persist preview PNG/PDF outputs and build designs from files
- refresh manual editor preview and PDF download

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0fef1e12483229476ac4260e51430