### PR TITLE
fix(manual): resolver path por file_idx, payload saneado, borrar real, cache-bust preview, errores claros

### DIFF
--- a/templates/montaje_offset_inteligente.html
+++ b/templates/montaje_offset_inteligente.html
@@ -182,7 +182,7 @@
     </div>
     <div class="stage" id="manual-stage" style="position:relative; overflow:auto; max-width:100%; max-height:70vh; border:1px solid #ddd; background:#fafafa;">
       <div id="viewport" style="position:relative; transform-origin: top left;">
-        <img id="preview-bg" src="{{ preview_url or '' }}" alt="preview" style="display:block; width:100%; height:auto;" />
+        <img id="preview_img" src="{{ preview_url or '' }}" alt="preview" style="display:block; width:100%; height:auto;" />
         <canvas id="overlay" tabindex="0" width="0" height="0" style="position:absolute; left:0; top:0; pointer-events:auto;"></canvas>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Sanitize manual editor payload and reindex boxes before sending
- Remove boxes permanently, refresh preview with cache busting and detailed errors
- Validate manual positions server-side resolving paths from file_idx

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b8735e0e3883228bf421ff4153a555