### PR TITLE
Add technical preview for flexographic diagnostics

### DIFF
--- a/preview_tecnico.py
+++ b/preview_tecnico.py
@@ -1,0 +1,81 @@
+import os
+import uuid
+import fitz
+import numpy as np
+from PIL import Image, ImageDraw
+from flask import current_app
+
+
+def generar_preview_tecnico(pdf_path: str, datos_formulario: dict, dpi: int = 200) -> str:
+    """Genera una imagen con advertencias técnicas.
+
+    Renderiza la primera página del PDF y resalta:
+    - Zonas con tramas < 5% (azul)
+    - Textos < 4 pt (naranja)
+    - Cobertura de tinta > 90% (rojo)
+    - Elementos en RGB u otros espacios de color no CMYK (gris oscuro)
+
+    Devuelve la ruta relativa dentro de ``static`` donde se guardó la imagen.
+    """
+    doc = fitz.open(pdf_path)
+    page = doc.load_page(0)
+    zoom = dpi / 72.0
+    mat = fitz.Matrix(zoom, zoom)
+    pix = page.get_pixmap(matrix=mat, alpha=False)
+    img = Image.frombytes("RGB", [pix.width, pix.height], pix.samples)
+
+    # Análisis de pixeles en CMYK
+    img_cmyk = img.convert("CMYK")
+    arr = np.array(img_cmyk)
+    h, w = arr.shape[:2]
+    overlay = np.zeros((h, w, 4), dtype=np.uint8)
+
+    # 🔵 Tramas <5%
+    weak_mask = ((arr > 0) & (arr < 13)).any(axis=2)
+    overlay[weak_mask] = [0, 0, 255, 120]
+
+    # 🔴 Cobertura >90%
+    coverage = arr.sum(axis=2) / (255 * 4)
+    high_mask = coverage > 0.9
+    overlay[high_mask] = [255, 0, 0, 120]
+
+    img_rgba = img.convert("RGBA")
+    overlay_img = Image.fromarray(overlay, "RGBA")
+    composed = Image.alpha_composite(img_rgba, overlay_img)
+    draw = ImageDraw.Draw(composed)
+
+    text_data = page.get_text("dict")
+    # 🟠 Textos <4 pt y ⚫ Elementos no CMYK
+    for block in text_data.get("blocks", []):
+        btype = block.get("type")
+        if btype == 0:  # texto
+            for line in block.get("lines", []):
+                for span in line.get("spans", []):
+                    if span.get("size", 0) < 4:
+                        x0, y0, x1, y1 = span["bbox"]
+                        rect = [x0 * zoom, y0 * zoom, x1 * zoom, y1 * zoom]
+                        draw.rectangle(rect, outline=(255, 165, 0, 255), width=2)
+        elif btype == 1:  # imagen
+            x0, y0, x1, y1 = block.get("bbox", (0, 0, 0, 0))
+            xref = block.get("image")
+            cs = ""
+            if xref:
+                try:
+                    info = doc.extract_image(xref)
+                    cs = info.get("colorspace", "")
+                except Exception:
+                    cs = ""
+            if cs and cs.upper() != "CMYK":
+                rect = [x0 * zoom, y0 * zoom, x1 * zoom, y1 * zoom]
+                draw.rectangle(rect, fill=(64, 64, 64, 120))
+
+    doc.close()
+
+    static_dir = getattr(current_app, "static_folder", "static")
+    previews_dir = os.path.join(static_dir, "previews")
+    os.makedirs(previews_dir, exist_ok=True)
+    filename = f"preview_tecnico_{uuid.uuid4().hex}.png"
+    output_abs = os.path.join(previews_dir, filename)
+    composed.save(output_abs)
+
+    return os.path.join("previews", filename)

--- a/routes.py
+++ b/routes.py
@@ -38,6 +38,7 @@ from montaje_flexo import (
     generar_sugerencia_produccion,
     corregir_sangrado_y_marcas,
 )
+from preview_tecnico import generar_preview_tecnico
 from montaje_offset import montar_pliego_offset
 from montaje_offset_inteligente import montar_pliego_offset_inteligente
 from montaje_offset_personalizado import montar_pliego_offset_personalizado
@@ -1250,6 +1251,23 @@ def revision_flexo():
         diagnostico_texto_b64=diagnostico_texto_b64,
         resultado_revision_b64=resultado_revision_b64,
     )
+
+
+@routes_bp.route("/vista_previa_tecnica", methods=["POST"])
+def vista_previa_tecnica():
+    try:
+        archivo = request.files.get("archivo_revision")
+        if not archivo or not archivo.filename.endswith(".pdf"):
+            return jsonify({"error": "Archivo inválido"}), 400
+        filename = secure_filename(archivo.filename)
+        path = os.path.join(UPLOAD_FOLDER_FLEXO, filename)
+        archivo.save(path)
+        datos = dict(request.form)
+        rel_path = generar_preview_tecnico(path, datos)
+        url = url_for("static", filename=rel_path)
+        return jsonify({"preview_url": url})
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
 
 
 @routes_bp.route("/sugerencia_ia", methods=["POST"])

--- a/static/js/flexografia.js
+++ b/static/js/flexografia.js
@@ -1,0 +1,29 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const btn = document.getElementById('vista-previa-btn');
+  const form = document.querySelector('form[action="/revision"]');
+  const previewContainer = document.getElementById('preview-container');
+  const img = document.getElementById('preview-img');
+
+  if (!btn) return;
+
+  btn.addEventListener('click', async (e) => {
+    e.preventDefault();
+    if (!form) return;
+    const data = new FormData(form);
+    previewContainer.innerHTML = '<p>Generando vista previa...</p>';
+    try {
+      const resp = await fetch('/vista_previa_tecnica', { method: 'POST', body: data });
+      const json = await resp.json();
+      if (!resp.ok) throw new Error(json.error || 'Error en vista previa');
+      if (json.preview_url) {
+        img.src = json.preview_url + '?v=' + Date.now();
+        previewContainer.innerHTML = '';
+        previewContainer.appendChild(img);
+      } else {
+        previewContainer.innerHTML = '<p>No se pudo generar la vista previa.</p>';
+      }
+    } catch (err) {
+      previewContainer.innerHTML = `<p>${err.message}</p>`;
+    }
+  });
+});

--- a/templates/revision_flexo.html
+++ b/templates/revision_flexo.html
@@ -152,6 +152,11 @@
       <button type="submit">Revisar diseño</button>
     </form>
 
+    <button id="vista-previa-btn" class="btn btn-secondary">Vista previa técnica</button>
+    <div id="preview-container" style="margin-top:20px;">
+      <img id="preview-img" src="" style="max-width:100%; border:1px solid #ccc;">
+    </div>
+
     {% if mensaje %}
       <div class="mensaje">{{ mensaje }}</div>
     {% endif %}
@@ -194,5 +199,6 @@
       </div>
     {% endif %}
   </div>
+  <script src="{{ url_for('static', filename='js/flexografia.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- generate technical preview images overlaying risky areas on flexo PDFs
- add `/vista_previa_tecnica` endpoint to request preview
- expose preview button and JS in revision template

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68baffdc31e88322b472d9b94b02ae89