### PR TITLE
Restringir vista previa técnica a diagnóstico previo

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,6 +7,7 @@ from routes import routes_bp
 app = Flask(__name__)
 app.config.from_object("config")
 app.config.setdefault("MAX_CONTENT_LENGTH", 32 * 1024 * 1024)
+app.secret_key = os.environ.get("SECRET_KEY", "dev-secret-key")
 os.makedirs(os.path.join(app.static_folder, "previews"), exist_ok=True)
 os.makedirs(os.path.join(app.static_folder, "outputs"), exist_ok=True)
 

--- a/montaje_flexo.py
+++ b/montaje_flexo.py
@@ -949,8 +949,13 @@ def revisar_diseño_flexo(
         + seccion_tinta_html
         + "</div>"
     )
+    analisis_detallado = {
+        "tramas_debiles": tramas_adv,
+        "cobertura_por_canal": cobertura,
+        "textos_pequenos": textos_adv,
+    }
     diagnostico_texto = generar_diagnostico_texto(resumen)
-    return resumen, imagen_tinta, diagnostico_texto
+    return resumen, imagen_tinta, diagnostico_texto, analisis_detallado
 
 
 def generar_diagnostico_texto(html_diagnostico: str) -> str:


### PR DESCRIPTION
## Summary
- Persistir resultados del diagnóstico flexo y su overlay para la vista previa técnica
- Reutilizar datos guardados y mostrar error si no hay diagnóstico previo
- Habilitar sesiones con una clave secreta por defecto

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb049a80588322bca0c4e9578ec6c0