### PR TITLE
Persist flexo diagnostic data for technical preview

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -1244,7 +1244,15 @@ def revision_flexo():
                 overlay_info = analizar_riesgos_pdf(path)
                 session["diagnostico_flexo"] = {
                     "pdf_path": path,
-                    "analisis": analisis_detallado,
+                    "resultados_diagnostico": analisis_detallado,
+                    "datos_formulario": {
+                        "anilox_lpi": anilox_lpi,
+                        "anilox_bcm": anilox_bcm,
+                        "paso_cilindro": paso_mm,
+                        "material": material,
+                        "velocidad_impresion": velocidad,
+                        "cobertura": cobertura,
+                    },
                     "overlay_path": overlay_info["overlay_path"],
                     "dpi": overlay_info["dpi"],
                 }
@@ -1270,7 +1278,7 @@ def revision_flexo():
 def vista_previa_tecnica():
     try:
         diag = session.get("diagnostico_flexo")
-        if not diag:
+        if not diag or "pdf_path" not in diag or "resultados_diagnostico" not in diag:
             return (
                 jsonify(
                     {
@@ -1282,7 +1290,7 @@ def vista_previa_tecnica():
 
         rel_path = generar_preview_tecnico(
             diag["pdf_path"],
-            {},
+            diag.get("datos_formulario"),
             overlay_path=diag.get("overlay_path"),
             dpi=diag.get("dpi", 200),
         )

--- a/static/js/flexografia.js
+++ b/static/js/flexografia.js
@@ -1,6 +1,5 @@
 document.addEventListener('DOMContentLoaded', () => {
   const btn = document.getElementById('vista-previa-btn');
-  const form = document.querySelector('form[action="/revision"]');
   const previewContainer = document.getElementById('preview-container');
   const img = document.getElementById('preview-img');
 
@@ -8,11 +7,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
   btn.addEventListener('click', async (e) => {
     e.preventDefault();
-    if (!form) return;
-    const data = new FormData(form);
     previewContainer.innerHTML = '<p>Generando vista previa...</p>';
     try {
-      const resp = await fetch('/vista_previa_tecnica', { method: 'POST', body: data });
+      const resp = await fetch('/vista_previa_tecnica', { method: 'POST' });
       const json = await resp.json();
       if (!resp.ok) throw new Error(json.error || 'Error en vista previa');
       if (json.preview_url) {


### PR DESCRIPTION
## Summary
- Save PDF path, diagnostic results, and form data in session when reviewing flexo designs
- Allow technical preview route to reuse stored session data
- Simplify preview JS to request preview without resending form data

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb092a6fa48322a5487f97cfaaef4c