### PR TITLE
Persist uploaded PDF for technical preview

### DIFF
--- a/static/js/flexografia.js
+++ b/static/js/flexografia.js
@@ -1,15 +1,16 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const btn = document.getElementById('vista-previa-btn');
+  const form = document.getElementById('vista-previa-form');
   const previewContainer = document.getElementById('preview-container');
   const img = document.getElementById('preview-img');
 
-  if (!btn) return;
+  if (!form) return;
 
-  btn.addEventListener('click', async (e) => {
+  form.addEventListener('submit', async (e) => {
     e.preventDefault();
     previewContainer.innerHTML = '<p>Generando vista previa...</p>';
     try {
-      const resp = await fetch('/vista_previa_tecnica', { method: 'POST' });
+      const formData = new FormData(form);
+      const resp = await fetch(form.action, { method: 'POST', body: formData });
       const json = await resp.json();
       if (!resp.ok) throw new Error(json.error || 'Error en vista previa');
       if (json.preview_url) {

--- a/templates/revision_flexo.html
+++ b/templates/revision_flexo.html
@@ -152,7 +152,10 @@
       <button type="submit">Revisar diseño</button>
     </form>
 
-    <button id="vista-previa-btn" class="btn btn-secondary">Vista previa técnica</button>
+    <form id="vista-previa-form" action="/vista_previa_tecnica" method="POST">
+      <input type="hidden" name="archivo_guardado" id="archivo_guardado" value="{{ session.get('archivo_pdf', '') }}">
+      <button id="vista-previa-btn" class="btn btn-secondary" type="submit">Vista previa técnica</button>
+    </form>
     <div id="preview-container" style="margin-top:20px;">
       <img id="preview-img" src="" style="max-width:100%; border:1px solid #ccc;">
     </div>


### PR DESCRIPTION
## Summary
- Store uploaded design PDFs in `static/uploads` and remember path in session
- Send saved PDF path from the diagnosis page and generate technical preview without re-upload

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb10bcbfa88322b2bec6d146bcc010