### PR TITLE
Overlay diagnostic warnings on virtual preview images

### DIFF
--- a/tests/test_preview_virtual.py
+++ b/tests/test_preview_virtual.py
@@ -1,0 +1,31 @@
+import os
+import fitz
+from PIL import Image
+from simulacion import generar_preview_virtual
+
+
+def test_generar_preview_virtual_overlay(tmp_path):
+    pdf_path = tmp_path / "sample.pdf"
+    doc = fitz.open()
+    doc.new_page(width=100, height=100)
+    doc.save(pdf_path)
+    doc.close()
+
+    advertencias = [
+        {
+            "page": 0,
+            "bbox": [10, 10, 60, 60],
+            "tipo": "texto_pequeno",
+            "label": "Texto <4pt",
+        }
+    ]
+
+    out_dir = tmp_path / "out"
+    paths = generar_preview_virtual(str(pdf_path), advertencias=advertencias, dpi=72, output_dir=str(out_dir))
+    assert len(paths) == 1
+    assert os.path.exists(paths[0])
+
+    img = Image.open(paths[0])
+    # Pixel inside the warning box should not be pure white due to overlay
+    pixel = img.getpixel((20, 20))
+    assert pixel != (255, 255, 255)


### PR DESCRIPTION
## Summary
- Expand `generar_preview_virtual` to draw color-coded warning boxes and labels onto PDF previews
- Support passing warning metadata and return generated image paths
- Add test confirming overlay rendering on generated preview

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb143c1768832284ae1caa44f48a59