### PR TITLE
Ensure technical overlay preview refreshes

### DIFF
--- a/preview_tecnico.py
+++ b/preview_tecnico.py
@@ -180,5 +180,6 @@ def generar_preview_tecnico(
     filename = f"preview_tecnico_overlay_{uuid.uuid4().hex}.png"
     output_abs = os.path.join(previews_dir, filename)
     composed.save(output_abs)
+    print("✅ Overlay generado en:", output_abs)
 
     return os.path.join("previews", filename)

--- a/routes.py
+++ b/routes.py
@@ -1324,6 +1324,7 @@ def vista_previa_tecnica():
             dpi=diag.get("dpi", 200),
         )
         url = url_for("static", filename=rel_path)
+        print("✅ Vista previa técnica disponible en:", url)
         return jsonify({"preview_url": url})
     except Exception as e:
         return jsonify({"error": str(e)}), 500

--- a/static/js/flexografia.js
+++ b/static/js/flexografia.js
@@ -14,7 +14,10 @@ document.addEventListener('DOMContentLoaded', () => {
       const json = await resp.json();
       if (!resp.ok) throw new Error(json.error || 'Error en vista previa');
       if (json.preview_url) {
-        img.src = json.preview_url + '?v=' + Date.now();
+        const cacheBust = (typeof crypto !== 'undefined' && crypto.randomUUID)
+          ? crypto.randomUUID()
+          : Date.now();
+        img.src = json.preview_url + '?v=' + cacheBust;
         previewContainer.innerHTML = '';
         previewContainer.appendChild(img);
       } else {


### PR DESCRIPTION
## Summary
- log overlay PNG generation path
- log preview URL served for technical view
- use random cache-busting parameter when loading preview image

## Testing
- `pytest tests/test_preview_tecnico_overlay.py::test_generar_preview_tecnico_overlay -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bb37fa888083229c97f434ae80690a