### PR TITLE
Evitar cache en vista previa técnica

### DIFF
--- a/preview_tecnico.py
+++ b/preview_tecnico.py
@@ -177,9 +177,11 @@ def generar_preview_tecnico(
     static_dir = getattr(current_app, "static_folder", "static")
     previews_dir = os.path.join(static_dir, "previews")
     os.makedirs(previews_dir, exist_ok=True)
-    filename = f"preview_tecnico_overlay_{uuid.uuid4().hex}.png"
+    # Guardar con nombre único para evitar caché en el navegador
+    filename = f"preview_tecnico_{uuid.uuid4().hex}.png"
     output_abs = os.path.join(previews_dir, filename)
     composed.save(output_abs)
-    print("✅ Overlay generado en:", output_abs)
+    # Informar en consola la ruta absoluta de salida
+    print("✅ Imagen compuesta guardada en:", output_abs)
 
     return os.path.join("previews", filename)

--- a/routes.py
+++ b/routes.py
@@ -1324,7 +1324,8 @@ def vista_previa_tecnica():
             dpi=diag.get("dpi", 200),
         )
         url = url_for("static", filename=rel_path)
-        print("✅ Vista previa técnica disponible en:", url)
+        # Mostrar en consola la URL pública generada
+        print("🌐 URL pública vista previa técnica:", url)
         return jsonify({"preview_url": url})
     except Exception as e:
         return jsonify({"error": str(e)}), 500

--- a/static/js/flexografia.js
+++ b/static/js/flexografia.js
@@ -8,6 +8,8 @@ document.addEventListener('DOMContentLoaded', () => {
   form.addEventListener('submit', async (e) => {
     e.preventDefault();
     previewContainer.innerHTML = '<p>Generando vista previa...</p>';
+    // Limpiar cualquier imagen previa mientras se genera una nueva
+    img.removeAttribute('src');
     try {
       const formData = new FormData(form);
       const resp = await fetch(form.action, { method: 'POST', body: formData });
@@ -17,13 +19,20 @@ document.addEventListener('DOMContentLoaded', () => {
         const cacheBust = (typeof crypto !== 'undefined' && crypto.randomUUID)
           ? crypto.randomUUID()
           : Date.now();
+        img.onload = () => {
+          previewContainer.innerHTML = '';
+          previewContainer.appendChild(img);
+        };
+        img.onerror = () => {
+          img.removeAttribute('src');
+          previewContainer.innerHTML = '<p>Error al cargar la vista previa.</p>';
+        };
         img.src = json.preview_url + '?v=' + cacheBust;
-        previewContainer.innerHTML = '';
-        previewContainer.appendChild(img);
       } else {
         previewContainer.innerHTML = '<p>No se pudo generar la vista previa.</p>';
       }
     } catch (err) {
+      img.removeAttribute('src');
       previewContainer.innerHTML = `<p>${err.message}</p>`;
     }
   });


### PR DESCRIPTION
## Summary
- Registrar ruta absoluta de la vista previa técnica con nombre único para evitar cache del navegador
- Mostrar en consola la URL pública generada de la vista previa
- Forzar recarga de imagen en frontend y limpiar previas en caso de error

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb52bb0b6083229c0a1eb8cc9d756d