### PR TITLE
Render flexo diagnostic overlays

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -1236,9 +1236,9 @@ def revision_flexo():
                 session["archivo_pdf"] = path
 
                 (
-                    resultado_revision,
-                    grafico_tinta,
-                    diagnostico_texto,
+                    resumen,
+                    imagen_tinta,
+                    texto,
                     analisis_detallado,
                     advertencias_overlay,
                 ) = revisar_diseño_flexo(
@@ -1268,22 +1268,21 @@ def revision_flexo():
                     "overlay_path": overlay_info["overlay_path"],
                     "dpi": overlay_info["dpi"],
                 }
-                resultado_revision_b64 = base64.b64encode(resultado_revision.encode("utf-8")).decode("utf-8")
-                diagnostico_texto_b64 = base64.b64encode(diagnostico_texto.encode("utf-8")).decode("utf-8")
+
+                return render_template(
+                    "resultado_flexo.html",
+                    resumen=resumen,
+                    imagen=imagen_tinta,
+                    texto=texto,
+                    analisis=analisis_detallado,
+                    overlay=advertencias_overlay,
+                )
             else:
                 mensaje = "Archivo inválido. Subí un PDF."
         except Exception as e:
             mensaje = f"Error al revisar diseño: {str(e)}"
 
-    return render_template(
-        "revision_flexo.html",
-        mensaje=mensaje,
-        resultado_revision=resultado_revision,
-        grafico_tinta=grafico_tinta,
-        diagnostico_texto=diagnostico_texto,
-        diagnostico_texto_b64=diagnostico_texto_b64,
-        resultado_revision_b64=resultado_revision_b64,
-    )
+    return render_template("revision_flexo.html", mensaje=mensaje)
 
 
 @routes_bp.route("/vista_previa_tecnica", methods=["POST"])

--- a/templates/resultado_flexo.html
+++ b/templates/resultado_flexo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <title>Resultado diagnóstico flexo</title>
+  <style>
+    #contenedor-imagen {
+      position: relative;
+      display: inline-block;
+    }
+    #contenedor-imagen img {
+      max-width: 100%;
+      height: auto;
+      display: block;
+    }
+    #contenedor-imagen div {
+      box-sizing: border-box;
+    }
+  </style>
+</head>
+<body>
+  <div id="contenedor-imagen" style="position: relative;">
+    <img src="data:image/png;base64,{{ imagen }}" id="imagen-diagnostico" />
+  </div>
+  <script>
+    const overlayData = {{ overlay|tojson }};
+    const contenedor = document.getElementById("contenedor-imagen");
+    const imagen = document.getElementById("imagen-diagnostico");
+
+    overlayData.forEach(item => {
+      const box = document.createElement("div");
+      box.style.position = "absolute";
+      box.style.border = "2px solid red";
+      box.style.left = item.bbox[0] + "px";
+      box.style.top = item.bbox[1] + "px";
+      box.style.width = (item.bbox[2] - item.bbox[0]) + "px";
+      box.style.height = (item.bbox[3] - item.bbox[1]) + "px";
+      box.title = item.tipo + ": " + item.etiqueta;
+      box.style.pointerEvents = "none";
+      contenedor.appendChild(box);
+    });
+  </script>
+  <div>{{ resumen|safe }}</div>
+  <pre>{{ texto }}</pre>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- return overlay data when diagnosing flexo files and render new `resultado_flexo.html` template
- display base design image with bounding boxes drawn from diagnostic warnings

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbbac2cf3c8322ac493f6ff5735bce