### PR TITLE
Fix flexo diagnosis preview flow

### DIFF
--- a/diagnostico_flexo.py
+++ b/diagnostico_flexo.py
@@ -1,0 +1,38 @@
+import os
+import fitz
+from typing import List, Dict, Any
+from flask import current_app
+
+
+def generar_preview_diagnostico(pdf_path: str, advertencias: List[Dict[str, Any]] | None, dpi: int = 150) -> tuple[str, str, List[Dict[str, Any]]]:
+    """Genera una imagen PNG del PDF para usar como base de superposición.
+
+    Devuelve una tupla con la ruta absoluta del archivo generado, la ruta
+    relativa para usar con ``url_for('static', filename=...)`` y la lista de
+    advertencias con las coordenadas escaladas al ``dpi`` solicitado.
+    """
+    doc = fitz.open(pdf_path)
+    page = doc.load_page(0)
+    zoom = dpi / 72.0
+    mat = fitz.Matrix(zoom, zoom)
+    pix = page.get_pixmap(matrix=mat, alpha=False)
+
+    static_dir = getattr(current_app, "static_folder", "static")
+    output_folder = os.path.join(static_dir, "previews")
+    os.makedirs(output_folder, exist_ok=True)
+    imagen_path = os.path.join(output_folder, "preview_diagnostico.png")
+    pix.save(imagen_path)
+    doc.close()
+
+    scale = dpi / 72.0
+    overlay_escalado: List[Dict[str, Any]] = []
+    if advertencias:
+        for adv in advertencias:
+            bbox = adv.get("bbox")
+            if bbox and len(bbox) == 4:
+                adv_scaled = adv.copy()
+                adv_scaled["bbox"] = [coord * scale for coord in bbox]
+                overlay_escalado.append(adv_scaled)
+
+    imagen_rel = os.path.join("previews", "preview_diagnostico.png")
+    return imagen_path, imagen_rel, overlay_escalado

--- a/routes.py
+++ b/routes.py
@@ -44,6 +44,7 @@ from montaje_offset import montar_pliego_offset
 from montaje_offset_inteligente import montar_pliego_offset_inteligente
 from montaje_offset_personalizado import montar_pliego_offset_personalizado
 from imposicion_offset_auto import imponer_pliego_offset_auto
+from diagnostico_flexo import generar_preview_diagnostico
 
 # Carpeta de subidas dentro de ``static`` para persistir archivos entre
 # formularios y poder servirlos directamente.
@@ -1237,7 +1238,7 @@ def revision_flexo():
 
                 (
                     resumen,
-                    imagen_tinta,
+                    _imagen_tinta,
                     texto,
                     analisis_detallado,
                     advertencias_overlay,
@@ -1252,6 +1253,10 @@ def revision_flexo():
                 )
                 overlay_info = analizar_riesgos_pdf(path)
                 overlay_info["advertencias"] = advertencias_overlay or overlay_info.get("advertencias", [])
+
+                _, imagen_rel, overlay_scaled = generar_preview_diagnostico(
+                    path, overlay_info["advertencias"], dpi=overlay_info["dpi"]
+                )
 
                 session["diagnostico_flexo"] = {
                     "pdf_path": path,
@@ -1272,10 +1277,10 @@ def revision_flexo():
                 return render_template(
                     "resultado_flexo.html",
                     resumen=resumen,
-                    imagen=imagen_tinta,
+                    imagen_path_web=imagen_rel,
                     texto=texto,
                     analisis=analisis_detallado,
-                    overlay=advertencias_overlay,
+                    overlay=overlay_scaled,
                 )
             else:
                 mensaje = "Archivo inválido. Subí un PDF."

--- a/templates/resultado_flexo.html
+++ b/templates/resultado_flexo.html
@@ -8,10 +8,24 @@
       position: relative;
       display: inline-block;
     }
-    #contenedor-imagen img {
-      max-width: 100%;
-      height: auto;
+    .imagen-analizada {
+      width: 100%;
+      max-width: 800px;
       display: block;
+      margin: auto;
+      position: relative;
+    }
+    .botones {
+      text-align: center;
+      margin-top: 20px;
+    }
+    .botones .btn {
+      display: inline-block;
+      padding: 10px 20px;
+      background: #0056b3;
+      color: #fff;
+      text-decoration: none;
+      border-radius: 4px;
     }
     #contenedor-imagen div {
       box-sizing: border-box;
@@ -20,27 +34,40 @@
 </head>
 <body>
   <div id="contenedor-imagen" style="position: relative;">
-    <img src="data:image/png;base64,{{ imagen }}" id="imagen-diagnostico" />
+    <img src="{{ url_for('static', filename=imagen_path_web) }}" id="imagen-diagnostico" class="imagen-analizada" />
   </div>
   <script>
     const overlayData = {{ overlay|tojson }};
     const contenedor = document.getElementById("contenedor-imagen");
     const imagen = document.getElementById("imagen-diagnostico");
 
-    overlayData.forEach(item => {
-      const box = document.createElement("div");
-      box.style.position = "absolute";
-      box.style.border = "2px solid red";
-      box.style.left = item.bbox[0] + "px";
-      box.style.top = item.bbox[1] + "px";
-      box.style.width = (item.bbox[2] - item.bbox[0]) + "px";
-      box.style.height = (item.bbox[3] - item.bbox[1]) + "px";
-      box.title = item.tipo + ": " + item.etiqueta;
-      box.style.pointerEvents = "none";
-      contenedor.appendChild(box);
-    });
+    function dibujarOverlays() {
+      const scaleX = imagen.clientWidth / imagen.naturalWidth;
+      const scaleY = imagen.clientHeight / imagen.naturalHeight;
+      overlayData.forEach(item => {
+        const box = document.createElement("div");
+        box.style.position = "absolute";
+        box.style.border = "2px solid red";
+        box.style.left = (item.bbox[0] * scaleX) + "px";
+        box.style.top = (item.bbox[1] * scaleY) + "px";
+        box.style.width = ((item.bbox[2] - item.bbox[0]) * scaleX) + "px";
+        box.style.height = ((item.bbox[3] - item.bbox[1]) * scaleY) + "px";
+        box.title = (item.tipo || "") + ": " + (item.etiqueta || "");
+        box.style.pointerEvents = "none";
+        contenedor.appendChild(box);
+      });
+    }
+
+    if (imagen.complete) {
+      dibujarOverlays();
+    } else {
+      imagen.onload = dibujarOverlays;
+    }
   </script>
   <div>{{ resumen|safe }}</div>
   <pre>{{ texto }}</pre>
+  <div class="botones">
+    <a href="{{ url_for('routes.revision_flexo') }}" class="btn">⬅ Volver a revisar otro diseño</a>
+  </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Generate preview_diagnostico.png from the analyzed PDF and scale overlay coordinates
- Render flexo results using the PDF preview as background with overlay boxes
- Preserve navigation controls below the flexo diagnosis results

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bbc165c31c83228b039d4b687b08d4