### PR TITLE
Remove duplicate diagnosis and show ink simulation image

### DIFF
--- a/montaje_flexo.py
+++ b/montaje_flexo.py
@@ -945,6 +945,8 @@ def revisar_diseño_flexo(
             seccion_tinta_html = (
                 "<div class='card'><h3>💧 Simulación de tinta</h3>"
                 f"<p>Cantidad estimada de tinta transferida: <b>{tinta_ml} ml/min</b></p>"
+                f"<img src='data:image/png;base64,{imagen_tinta}' alt='Vista previa de tinta' "
+                "style='max-width:100%; height:auto; margin-top:10px;'>"
                 f"{barra_html}"
                 f"<p>{advertencia_tinta}</p>"
                 "</div>"

--- a/templates/resultado_flexo.html
+++ b/templates/resultado_flexo.html
@@ -65,7 +65,6 @@
     }
   </script>
   <div>{{ resumen|safe }}</div>
-  <pre>{{ texto }}</pre>
   <div class="botones">
     <a href="{{ url_for('routes.revision_flexo') }}" class="btn">⬅ Volver a revisar otro diseño</a>
   </div>


### PR DESCRIPTION
## Summary
- Avoid duplicate diagnostic text on the result page.
- Reintroduce ink simulation preview with responsive image styling.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbc6e43520832289655d9b95a0a0a0