### PR TITLE
Add risk simulator for flexo diagnostics

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -45,6 +45,7 @@ from montaje_offset_inteligente import montar_pliego_offset_inteligente
 from montaje_offset_personalizado import montar_pliego_offset_personalizado
 from imposicion_offset_auto import imponer_pliego_offset_auto
 from diagnostico_flexo import generar_preview_diagnostico
+from simulador_riesgos import simular_riesgos
 
 # Carpeta de subidas dentro de ``static`` para persistir archivos entre
 # formularios y poder servirlos directamente.
@@ -1258,6 +1259,8 @@ def revision_flexo():
                     path, overlay_info["advertencias"], dpi=overlay_info["dpi"]
                 )
 
+                tabla_riesgos = simular_riesgos(resumen)
+
                 session["diagnostico_flexo"] = {
                     "pdf_path": path,
                     "resultados_diagnostico": analisis_detallado,
@@ -1277,6 +1280,7 @@ def revision_flexo():
                 return render_template(
                     "resultado_flexo.html",
                     resumen=resumen,
+                    tabla_riesgos=tabla_riesgos,
                     imagen_path_web=imagen_rel,
                     texto=texto,
                     analisis=analisis_detallado,

--- a/simulador_riesgos.py
+++ b/simulador_riesgos.py
@@ -1,0 +1,118 @@
+"""Simulador de riesgos para diagnóstico flexográfico.
+
+Este módulo aplica reglas fijas para clasificar el nivel de riesgo de
+advertencias detectadas en un diagnóstico flexográfico. No utiliza IA ni
+requiere conexión externa, aunque se deja un parámetro ``usar_ia`` para una
+posible integración futura.
+"""
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Dict, List
+
+
+def _a_texto(diagnostico: Any) -> str:
+    """Convierte el diagnóstico a un texto en minúsculas."""
+    if isinstance(diagnostico, str):
+        return diagnostico.lower()
+    try:
+        return json.dumps(diagnostico, ensure_ascii=False).lower()
+    except Exception:
+        return str(diagnostico).lower()
+
+
+def simular_riesgos(diagnostico: str | Dict[str, Any], usar_ia: bool = False) -> str:
+    """Evalúa reglas fijas sobre el diagnóstico dado.
+
+    Parameters
+    ----------
+    diagnostico: str | dict
+        Resumen estructurado del diagnóstico, puede ser texto plano o un
+        diccionario con información relevante.
+    usar_ia: bool, optional
+        Bandera reservada para futuras integraciones con análisis por IA.
+
+    Returns
+    -------
+    str
+        HTML con una tabla que resume los riesgos detectados.
+    """
+
+    texto = _a_texto(diagnostico)
+    resultados: List[Dict[str, str]] = []
+
+    def agregar(problema: str, nivel: str, sugerencia: str) -> None:
+        resultados.append(
+            {"problema": problema, "nivel": nivel, "sugerencia": sugerencia}
+        )
+
+    # Reglas fijas
+    if re.search(r"text[oa]s?\s*(<|menores a)\s*4\s*pt", texto) or "texto pequeño" in texto:
+        agregar("Textos < 4 pt", "🔴 Alto", "Aumentar a 5 pt mínimo para flexografía")
+
+    if re.search(r"traz[ao]s?\s*(<|menores a)\s*0\.25\s*pt", texto) or "trazo_fino" in texto:
+        agregar("Trazos < 0.25 pt", "🔴 Alto", "Engrosar trazos a 0.30 pt mínimo")
+
+    if re.search(r"resoluci[óo]n.*<\s*300\s*dpi", texto):
+        agregar(
+            "Resolución < 300 dpi",
+            "🟡 Medio",
+            "Incrementar la resolución de imágenes a 300 dpi",
+        )
+
+    if "rgb" in texto or ("pantone" in texto and "sin nombre" in texto):
+        agregar(
+            "Elementos fuera de CMYK",
+            "🟡 Medio",
+            "Convertir a CMYK antes de exportar PDF",
+        )
+
+    if "overprint" in texto or "sobreimpresi" in texto:
+        agregar(
+            "Sobreimpresión activa",
+            "🔴 Alto",
+            "Revisar configuraciones de sobreimpresión",
+        )
+
+    m_tac = re.search(r"tac[^0-9]*(\d+)", texto)
+    if m_tac:
+        tac_val = int(m_tac.group(1))
+        if tac_val > 320:
+            agregar("TAC > 320%", "🔴 Alto", "Reducir cobertura total de tinta")
+        elif 280 <= tac_val <= 320:
+            agregar("TAC 280%-320%", "🟡 Medio", "Optimizar separaciones para bajar TAC")
+
+    if "2 mm" in texto and ("borde" in texto or "margen" in texto):
+        agregar(
+            "Elementos < 2 mm del borde",
+            "🟡 Medio",
+            "Aumentar margen de seguridad a 2 mm",
+        )
+
+    if "sin sangrado" in texto or "no se detect" in texto and "sangrado" in texto:
+        agregar("Sin sangrado", "🟡 Medio", "Agregar 3 mm de sangrado")
+
+    if "contraste débil" in texto or "contraste debil" in texto:
+        agregar(
+            "Contraste débil",
+            "🟡 Medio",
+            "Revisar contraste de elementos",
+        )
+
+    if not resultados:
+        return (
+            "<div id='tabla-riesgos'><p>Sin riesgos detectados con las reglas establecidas.</p></div>"
+        )
+
+    filas = "".join(
+        f"<tr><td>{r['problema']}</td><td>{r['nivel']}</td><td>{r['sugerencia']}</td></tr>"
+        for r in resultados
+    )
+    tabla = (
+        "<div id='tabla-riesgos'>"
+        "<table style='border-collapse:collapse; margin-top:20px; width:100%;'>"
+        "<thead><tr><th>Problema detectado</th><th>Nivel de riesgo</th><th>Sugerencia</th></tr></thead>"
+        f"<tbody>{filas}</tbody></table></div>"
+    )
+    return tabla

--- a/templates/resultado_flexo.html
+++ b/templates/resultado_flexo.html
@@ -30,6 +30,19 @@
     #contenedor-imagen div {
       box-sizing: border-box;
     }
+    #tabla-riesgos table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 20px;
+    }
+    #tabla-riesgos th, #tabla-riesgos td {
+      border: 1px solid #ccc;
+      padding: 8px;
+      text-align: left;
+    }
+    #tabla-riesgos th {
+      background: #f0f0f0;
+    }
   </style>
 </head>
 <body>
@@ -64,7 +77,8 @@
       imagen.onload = dibujarOverlays;
     }
   </script>
-  <div>{{ resumen|safe }}</div>
+  <div id="resumen-diagnostico">{{ resumen|safe }}</div>
+  {{ tabla_riesgos|safe }}
   <div class="botones">
     <a href="{{ url_for('routes.revision_flexo') }}" class="btn">⬅ Volver a revisar otro diseño</a>
   </div>


### PR DESCRIPTION
## Summary
- implement `simular_riesgos` with fixed risk rules and optional AI hook
- show risk table in flexo results page
- integrate risk simulator into flexo review route

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bbcde7c5e883228c89ff552c264d16