### PR TITLE
feat: mejorar diagnostico flexo

### DIFF
--- a/diagnostico_flexo.py
+++ b/diagnostico_flexo.py
@@ -1,10 +1,13 @@
 import os
 import fitz
-from typing import List, Dict, Any
+import numpy as np
+from typing import List, Dict, Any, Tuple
 from flask import current_app
 
 
-def generar_preview_diagnostico(pdf_path: str, advertencias: List[Dict[str, Any]] | None, dpi: int = 150) -> tuple[str, str, List[Dict[str, Any]]]:
+def generar_preview_diagnostico(
+    pdf_path: str, advertencias: List[Dict[str, Any]] | None, dpi: int = 150
+) -> tuple[str, str, List[Dict[str, Any]]]:
     """Genera una imagen PNG del PDF para usar como base de superposición.
 
     Devuelve una tupla con la ruta absoluta del archivo generado, la ruta
@@ -36,3 +39,124 @@ def generar_preview_diagnostico(pdf_path: str, advertencias: List[Dict[str, Any]
 
     imagen_rel = os.path.join("previews", "preview_diagnostico.png")
     return imagen_path, imagen_rel, overlay_escalado
+
+
+# ---------------------------------------------------------------------------
+# Utilidades de diagnóstico flexográfico
+# ---------------------------------------------------------------------------
+
+
+def calcular_cobertura_y_tac(
+    pdf_path: str, dpi: int = 72
+) -> Tuple[Dict[str, float], float]:
+    """Calcula cobertura por canal CMYK y el TAC p95 real del diseño.
+
+    ``cobertura`` representa el porcentaje promedio de tinta en cada canal y
+    ``tac_p95`` el percentil 95 del Total Area Coverage.
+    """
+
+    doc = fitz.open(pdf_path)
+    page = doc.load_page(0)
+    zoom = dpi / 72.0
+    mat = fitz.Matrix(zoom, zoom)
+    pix = page.get_pixmap(matrix=mat, colorspace=fitz.csCMYK, alpha=False)
+    img = np.frombuffer(pix.samples, dtype=np.uint8).reshape(
+        pix.height, pix.width, pix.n
+    )
+    doc.close()
+
+    canales = ["Cyan", "Magenta", "Amarillo", "Negro"]
+    coberturas = {
+        canal: float(img[:, :, i].mean() / 255.0 * 100.0)
+        for i, canal in enumerate(canales)
+    }
+
+    coberturas_cmyk_sumadas = img.sum(axis=2) / 255.0 * 100.0
+    tac_p95 = float(np.percentile(coberturas_cmyk_sumadas, 95))
+
+    return coberturas, tac_p95
+
+
+def detectar_trama_debil_negro(
+    img: np.ndarray, umbral: float = 5.0
+) -> List[Dict[str, Any]]:
+    """Evalúa trama débil en el canal negro.
+
+    Si la cobertura del canal K es 0%, la evaluación se omite.
+    Devuelve una lista con advertencias encontradas, vacía si no hay riesgo.
+    """
+
+    resultados: List[Dict[str, Any]] = []
+    if img.shape[2] < 4:
+        return resultados
+
+    canal_k = img[:, :, 3]
+    if not np.any(canal_k):
+        return resultados
+
+    limite = umbral / 100.0 * 255.0
+    mask = (canal_k > 0) & (canal_k < limite)
+    if np.any(mask):
+        resultados.append(
+            {"mensaje": "Trama débil detectada en canal negro", "nivel": "medio"}
+        )
+
+    return resultados
+
+
+def filtrar_objetos_sistema(
+    objetos: List[Dict[str, Any]], advertencias: List[Dict[str, Any]]
+) -> List[Dict[str, Any]]:
+    """Excluye del análisis los trazos generados por el sistema (overlays)."""
+
+    advertencias_bboxes = {
+        tuple(adv.get("bbox")) for adv in advertencias or [] if adv.get("bbox")
+    }
+    filtrados: List[Dict[str, Any]] = []
+    for obj in objetos:
+        bbox = tuple(obj.get("bbox")) if obj.get("bbox") else None
+        if obj.get("id", "").startswith("sistema"):
+            continue
+        if bbox and bbox in advertencias_bboxes:
+            continue
+        filtrados.append(obj)
+    return filtrados
+
+
+def resumen_advertencias(advertencias: List[Dict[str, Any]]) -> str:
+    """Genera un resumen global de advertencias clasificado por nivel."""
+
+    if not advertencias:
+        return "✅ Archivo sin riesgos detectados. Listo para enviar a clichés."
+
+    niveles = {"critico": 0, "medio": 0, "leve": 0}
+    for adv in advertencias:
+        nivel = adv.get("nivel", "leve")
+        if nivel not in niveles:
+            nivel = "leve"
+        niveles[nivel] += 1
+
+    total = sum(niveles.values())
+    return (
+        f"Este archivo presenta {total} advertencias: "
+        f"{niveles['critico']} críticas (🔴), "
+        f"{niveles['medio']} medias (🟡) y "
+        f"{niveles['leve']} leves (🟢)."
+    )
+
+
+def nivel_riesgo_global(advertencias: List[Dict[str, Any]]) -> str:
+    """Calcula el nivel global de riesgo basado en las advertencias."""
+
+    if any(adv.get("nivel") == "critico" for adv in advertencias):
+        return "alto"
+    if any(adv.get("nivel") == "medio" for adv in advertencias):
+        return "medio"
+    return "bajo"
+
+
+def semaforo_riesgo(advertencias: List[Dict[str, Any]]) -> str:
+    """Representación con emoji del nivel de riesgo."""
+
+    nivel = nivel_riesgo_global(advertencias)
+    return {"alto": "🔴", "medio": "🟡", "bajo": "🟢"}[nivel]

--- a/tests/test_diagnostico_flexo.py
+++ b/tests/test_diagnostico_flexo.py
@@ -1,0 +1,56 @@
+"""Tests para utilidades de diagnostico flexográfico."""
+
+import fitz
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from diagnostico_flexo import (
+    calcular_cobertura_y_tac,
+    resumen_advertencias,
+    semaforo_riesgo,
+)
+
+
+def test_calcular_cobertura_y_tac(tmp_path):
+    """La cobertura por canal refleja los porcentajes reales y el TAC p95."""
+
+    doc = fitz.open()
+    page = doc.new_page()
+    rect = fitz.Rect(0, 0, page.rect.width / 2, page.rect.height)
+    # Mitad de la página con tinta negra
+    page.draw_rect(rect, color=(0, 0, 0, 1), fill=(0, 0, 0, 1))
+    pdf_path = tmp_path / "ejemplo.pdf"
+    doc.save(pdf_path)
+    doc.close()
+
+    coberturas, tac_p95 = calcular_cobertura_y_tac(str(pdf_path))
+    assert 40 < coberturas["Negro"] < 60
+    assert (
+        coberturas["Cyan"] < 1
+        and coberturas["Magenta"] < 1
+        and coberturas["Amarillo"] < 1
+    )
+    assert 95 <= tac_p95 <= 100
+
+
+def test_resumen_y_semaforo():
+    advertencias = [
+        {"nivel": "critico"},
+        {"nivel": "medio"},
+        {"nivel": "medio"},
+        {"nivel": "leve"},
+    ]
+
+    resumen = resumen_advertencias(advertencias)
+    assert "4 advertencias" in resumen
+    assert "1 críticas" in resumen
+    assert "2 medias" in resumen
+    assert "1 leves" in resumen
+    assert semaforo_riesgo(advertencias) == "🔴"
+
+
+def test_resumen_sin_advertencias():
+    assert resumen_advertencias([]).startswith("✅ Archivo sin riesgos")
+    assert semaforo_riesgo([]) == "🟢"


### PR DESCRIPTION
## Summary
- calculate real CMYK coverage and TAC p95 for flexographic diagnostics
- ignore system overlays and only evaluate weak black screens when K is present
- add global warning summary and risk semaphore helpers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0d027b9c4832292a4cba1a5ed8be5