### PR TITLE
Ensure default warning text when description is missing

### DIFF
--- a/templates/resultado_flexo.html
+++ b/templates/resultado_flexo.html
@@ -127,7 +127,7 @@
     } %}
     {% for adv in advertencias_iconos %}
       <li data-idx="{{ loop.index0 }}">
-        <span class="cuadro-alerta {{ tipo_clases.get(adv.tipo, '') }}"></span>{{ adv.mensaje }}
+        <span class="cuadro-alerta {{ tipo_clases.get(adv.tipo, '') }}"></span>{{ (adv.mensaje | default('', true) | trim) or 'Advertencia sin descripción detallada.' }}
       </li>
     {% endfor %}
   </ul>
@@ -166,7 +166,7 @@
       advertencias.forEach((item, idx) => {
         const icon = document.createElement('span');
         icon.className = 'warning-marker ' + (tipoClase[item.tipo] || '');
-        const texto = (item.mensaje && item.mensaje.trim()) ? item.mensaje : 'Advertencia sin descripción';
+        const texto = (item.mensaje && item.mensaje.trim()) ? item.mensaje.trim() : 'Advertencia sin descripción detallada.';
         icon.textContent = texto;
         icon.style.left = (item.pos[0] * scaleX) + 'px';
         icon.style.top = (item.pos[1] * scaleY) + 'px';

--- a/tests/test_resultado_flexo_template.py
+++ b/tests/test_resultado_flexo_template.py
@@ -1,0 +1,19 @@
+from flask import Flask, render_template
+from pathlib import Path
+
+
+def test_default_warning_message_in_template():
+    base_path = Path(__file__).resolve().parents[1]
+    app = Flask(__name__, template_folder=str(base_path / 'templates'), static_folder=str(base_path / 'static'))
+    app.add_url_rule('/', endpoint='routes.revision_flexo', view_func=lambda: '')
+    with app.app_context():
+        with app.test_request_context():
+            html = render_template(
+                'resultado_flexo.html',
+                imagen_path_web='dummy.png',
+                advertencias_iconos=[{'tipo': 'texto_pequeno', 'pos': [0, 0], 'mensaje': None}],
+                resumen='',
+                tabla_riesgos='',
+                imagen_iconos_web='dummy.png',
+            )
+    assert 'Advertencia sin descripción detallada.' in html


### PR DESCRIPTION
## Summary
- show "Advertencia sin descripción detallada." in `resultado_flexo.html` when warning message is empty
- test template rendering for warnings without description

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c12113f2e08322a450efbe5d687fb0