### PR TITLE
Add live flexo simulation and expose diagnostic JSON

### DIFF
--- a/montaje_flexo.py
+++ b/montaje_flexo.py
@@ -590,6 +590,12 @@ def revisar_diseño_flexo(
     sangrado_adv = adv_res["sangrado"]
     advertencias_overlay = adv_res["overlay"]
     resolucion_items = verificar_resolucion_imagenes(path_pdf)
+    resolucion_minima = None
+    for item in resolucion_items:
+        m = re.search(r">\s*(\d+)\s*DPI", item)
+        if m:
+            dpi = int(m.group(1))
+            resolucion_minima = dpi if resolucion_minima is None else min(resolucion_minima, dpi)
     if metricas_cobertura:
         til_items = resumen_cobertura_tac(metricas_cobertura, material)
     else:
@@ -742,6 +748,8 @@ def revisar_diseño_flexo(
         "tramas_debiles": tramas_adv,
         "cobertura_por_canal": metricas_cobertura["cobertura_promedio"] if metricas_cobertura else {},
         "textos_pequenos": textos_adv,
+        "resolucion_minima": resolucion_minima or 0,
+        "trama_minima": 5,
     }
     diagnostico_texto = generar_diagnostico_texto(resumen)
     return resumen, imagen_tinta, diagnostico_texto, analisis_detallado, advertencias_overlay

--- a/routes.py
+++ b/routes.py
@@ -1263,6 +1263,23 @@ def revision_flexo():
 
                 tabla_riesgos = simular_riesgos(resumen)
 
+                cobertura_dict = analisis_detallado.get("cobertura_por_canal", {})
+                diagnostico_json = {
+                    "cobertura": {
+                        "C": round(cobertura_dict.get("Cyan", 0)),
+                        "M": round(cobertura_dict.get("Magenta", 0)),
+                        "Y": round(cobertura_dict.get("Amarillo", 0)),
+                        "K": round(cobertura_dict.get("Negro", 0)),
+                    },
+                    "trama_minima": analisis_detallado.get("trama_minima", 5),
+                    "resolucion_minima": analisis_detallado.get("resolucion_minima", 0),
+                    "textos_pequenos": [
+                        {"tamano": o.get("tamano"), "color": o.get("color")}
+                        for o in advertencias_overlay
+                        if o.get("tipo") == "texto_pequeno"
+                    ],
+                }
+
                 session["diagnostico_flexo"] = {
                     "pdf_path": path,
                     "resultados_diagnostico": analisis_detallado,
@@ -1288,6 +1305,7 @@ def revision_flexo():
                     texto=texto,
                     analisis=analisis_detallado,
                     advertencias_iconos=advertencias_iconos,
+                    diagnostico_json=diagnostico_json,
                 )
             else:
                 mensaje = "Archivo inválido. Subí un PDF."

--- a/static/js/simulacion_flexo.js
+++ b/static/js/simulacion_flexo.js
@@ -1,0 +1,51 @@
+// Simulación de impresión flexográfica en vivo
+function inicializarSimulacionFlexo() {
+  const btn = document.getElementById('btn-simulacion-flexo');
+  const panel = document.getElementById('panel-simulacion');
+  const cerrar = document.getElementById('cerrar-simulacion');
+  const lpi = document.getElementById('sim-lpi');
+  const bcm = document.getElementById('sim-bcm');
+  const vel = document.getElementById('sim-velocidad');
+  const canvas = document.getElementById('sim-canvas');
+  if (!btn || !panel || !canvas) return;
+  const ctx = canvas.getContext('2d');
+  const img = new Image();
+  const baseImg = document.getElementById('imagen-diagnostico');
+  if (baseImg) {
+    img.src = baseImg.src;
+  }
+  const datos = window.diagnosticoFlexo || {};
+  function dibujar() {
+    const valLpi = parseFloat(lpi.value);
+    const valBcm = parseFloat(bcm.value);
+    const valVel = parseFloat(vel.value);
+    const cobertura = datos.cobertura || {};
+    const promedio = (cobertura.C + cobertura.M + cobertura.Y + cobertura.K) / 400 || 0;
+    ctx.clearRect(0,0,canvas.width,canvas.height);
+    if (img.complete) {
+      ctx.globalAlpha = 1 - ((valVel - 50) / 250) * 0.3;
+      ctx.filter = `saturate(${0.5 + (valBcm - 1) / 7}) brightness(${0.8 + promedio})`;
+      ctx.drawImage(img,0,0,canvas.width,canvas.height);
+      ctx.filter = 'none';
+    }
+    ctx.globalAlpha = 1;
+    const spacing = 10;
+    const radio = (600 - valLpi) / 400 * 3 + 1;
+    ctx.fillStyle = 'rgba(0,0,0,0.2)';
+    for (let y=0; y<canvas.height; y+=spacing) {
+      for (let x=0; x<canvas.width; x+=spacing) {
+        ctx.beginPath();
+        ctx.arc(x, y, radio, 0, Math.PI*2);
+        ctx.fill();
+      }
+    }
+  }
+  img.onload = dibujar;
+  lpi.addEventListener('input', dibujar);
+  bcm.addEventListener('input', dibujar);
+  vel.addEventListener('input', dibujar);
+  btn.addEventListener('click', () => panel.classList.add('abierto'));
+  cerrar.addEventListener('click', () => panel.classList.remove('abierto'));
+}
+
+document.addEventListener('DOMContentLoaded', inicializarSimulacionFlexo);

--- a/templates/resultado_flexo.html
+++ b/templates/resultado_flexo.html
@@ -131,6 +131,24 @@
     .warning-icon.tipo-resolucion { background: orange; }
     .warning-icon.tipo-overprint { background: blue; }
     .warning-icon.tipo-borde { background: darkgreen; }
+
+    #panel-simulacion {
+      position: fixed;
+      top: 0;
+      right: 0;
+      width: 300px;
+      height: 100%;
+      background: #fff;
+      box-shadow: -2px 0 5px rgba(0,0,0,0.3);
+      transform: translateX(100%);
+      transition: transform 0.3s;
+      z-index: 10001;
+      padding: 15px;
+      overflow-y: auto;
+    }
+    #panel-simulacion.abierto { transform: translateX(0); }
+    #panel-simulacion label { display: block; margin-top: 10px; }
+    #panel-simulacion canvas { width: 100%; border: 1px solid #ccc; margin-top: 10px; }
   </style>
 </head>
 <body>
@@ -281,8 +299,20 @@
   <div id="resumen-diagnostico">{{ resumen|safe }}</div>
   {{ tabla_riesgos|safe }}
   <div class="botones">
+    <button id="btn-simulacion-flexo" class="btn" type="button">Simulación Flexo</button>
     <a href="{{ url_for('static', filename=imagen_iconos_web) }}" class="btn" download>⬇ Descargar imagen con advertencias</a>
     <a href="{{ url_for('routes.revision_flexo') }}" class="btn">⬅ Volver a revisar otro diseño</a>
   </div>
+  <div id="panel-simulacion">
+    <button id="cerrar-simulacion" class="btn" type="button">Cerrar ✖</button>
+    <label>Anilox LPI: <input type="range" id="sim-lpi" min="200" max="600" value="400"></label>
+    <label>BCM: <input type="range" id="sim-bcm" min="1" max="8" step="0.1" value="4"></label>
+    <label>Velocidad (m/min): <input type="range" id="sim-velocidad" min="50" max="300" value="150"></label>
+    <canvas id="sim-canvas" width="280" height="280"></canvas>
+  </div>
+  <script>
+    window.diagnosticoFlexo = {{ diagnostico_json | default({}) | tojson }};
+  </script>
+  <script src="{{ url_for('static', filename='js/simulacion_flexo.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Export diagnostics as a JSON object for frontend access
- Add "Simulación Flexo" button with sliders and canvas panel
- Implement live canvas simulation reacting to LPI, BCM and speed

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c4fe38ff2083228cab4d7561d597c8