### PR TITLE
feat: enhance ink simulation details

### DIFF
--- a/templates/resultado_flexo.html
+++ b/templates/resultado_flexo.html
@@ -306,13 +306,18 @@
   <div id="panel-simulacion">
     <button id="cerrar-simulacion" class="btn" type="button">Cerrar ✖</button>
     <label>Anilox LPI: <input type="range" id="sim-lpi" min="200" max="600" value="400"></label>
-    <label>BCM: <input type="range" id="sim-bcm" min="1" max="8" step="0.1" value="4"></label>
+    <label>BCM (ml/m²): <input type="range" id="sim-bcm" min="1" max="8" step="0.1" value="4"></label>
     <label>Velocidad (m/min): <input type="range" id="sim-velocidad" min="50" max="300" value="150"></label>
+    <label>Eficiencia (0-1): <input type="range" id="sim-eficiencia" min="0" max="1" step="0.01" value="0.30"></label>
+    <label>Ancho (m): <input type="number" id="sim-ancho" min="0.1" step="0.01" value="0.50"></label>
     <canvas id="sim-canvas" width="280" height="280"></canvas>
+    <canvas id="sim-grafico" width="280" height="200"></canvas>
+    <div id="sim-detalles"></div>
   </div>
   <script>
     window.diagnosticoFlexo = {{ diagnostico_json | default({}) | tojson }};
   </script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="{{ url_for('static', filename='js/simulacion_flexo.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add adjustable efficiency and width inputs to ink simulation panel
- compute and chart ml/min vs ideal values with dynamic axis
- show calculation details including substituted formula

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c507218bfc83229a848eb9aa0e0ac4