### PR TITLE
Separar simulación flexo en bloques independientes

### DIFF
--- a/static/js/simulacion_flexo.js
+++ b/static/js/simulacion_flexo.js
@@ -1,85 +1,62 @@
-// Simulación de impresión flexográfica en vivo
-function inicializarSimulacionFlexo() {
+// Simulación de impresión flexográfica dividida en bloques
+
+document.addEventListener('DOMContentLoaded', () => {
+  inicializarSimulacionReticula();
+  inicializarSimulacionTinta();
+});
+
+function obtenerDatosBase() {
+  const datos = window.diagnosticoFlexo || {};
+  const coberturaDatos = datos.cobertura || {};
+  const tac = typeof datos.tac_p95 === 'number' ? datos.tac_p95 : null;
+  const cobertura = Math.min(
+    1,
+    Math.max(
+      0,
+      tac
+        ? tac / 400
+        : (coberturaDatos.C + coberturaDatos.M + coberturaDatos.Y + coberturaDatos.K) /
+          400
+    )
+  );
+  const sustrato = datos.material || 'papel';
+  return { datos, cobertura, sustrato };
+}
+
+// --- Bloque de simulación en vivo (retícula) ---
+function inicializarSimulacionReticula() {
   const btn = document.getElementById('btn-simulacion-flexo');
-  const panel = document.getElementById('panel-simulacion');
+  const modal = document.getElementById('simulacion-en-vivo');
   const cerrar = document.getElementById('cerrar-simulacion');
   const lpi = document.getElementById('sim-lpi');
   const bcm = document.getElementById('sim-bcm');
   const vel = document.getElementById('sim-velocidad');
   const canvasTrama = document.getElementById('sim-canvas');
-  const eficiencia = document.getElementById('sim-eficiencia');
-  const ancho = document.getElementById('sim-ancho');
-  const canvasGrafico = document.getElementById('sim-grafico');
-  const detalles = document.getElementById('sim-detalles');
-  if (!btn || !panel || !canvasTrama || !canvasGrafico || !bcm || !vel || !ancho || !eficiencia) return;
+  if (!btn || !modal || !cerrar || !lpi || !bcm || !vel || !canvasTrama) return;
 
-  // Preparar capa de textos separada
+  const { datos } = obtenerDatosBase();
+  const textos = datos.textos_pequenos || [];
+
   const canvasTextos = document.createElement('canvas');
   canvasTextos.id = 'sim-canvas-textos';
   canvasTextos.width = canvasTrama.width;
   canvasTextos.height = canvasTrama.height;
-  panel.style.position = 'relative';
+  const contenedorCanvas = document.getElementById('sim-canvas-container');
+  contenedorCanvas.style.position = 'relative';
   canvasTrama.style.position = canvasTextos.style.position = 'absolute';
   canvasTrama.style.top = canvasTextos.style.top = '0';
   canvasTrama.style.left = canvasTextos.style.left = '0';
   canvasTrama.style.zIndex = '1';
   canvasTextos.style.zIndex = '2';
-  panel.appendChild(canvasTextos);
+  contenedorCanvas.appendChild(canvasTextos);
 
   const ctxTrama = canvasTrama.getContext('2d');
   const ctxTextos = canvasTextos.getContext('2d');
-  const ctxGrafico = canvasGrafico.getContext('2d');
 
   const img = new Image();
   const baseImg = document.getElementById('imagen-diagnostico');
   if (baseImg) {
     img.src = baseImg.src;
-  }
-
-  const datos = window.diagnosticoFlexo || {};
-  const textos = datos.textos_pequenos || [];
-  const coberturaDatos = datos.cobertura || {};
-  const tac = typeof datos.tac_p95 === 'number' ? datos.tac_p95 : null;
-  const cobertura = Math.min(1, Math.max(0, tac ? tac / 400 : (coberturaDatos.C + coberturaDatos.M + coberturaDatos.Y + coberturaDatos.K) / 400));
-  const sustrato = datos.material || 'papel';
-
-  let chart;
-  function inicializarGrafico() {
-    chart = new Chart(ctxGrafico, {
-      type: 'bar',
-      data: {
-        labels: ['Calculado', 'Ideal'],
-        datasets: [{
-          label: 'ml/min',
-          backgroundColor: ['#36a2eb', '#4caf50'],
-          data: [0, 0]
-        }]
-      },
-      options: {
-        responsive: false,
-        scales: {
-          y: {
-            beginAtZero: true,
-            title: { display: true, text: 'ml/min' }
-          }
-        }
-      }
-    });
-  }
-
-  function actualizarCalculo() {
-    const bcmVal = parseFloat(bcm.value);
-    const eficienciaVal = parseFloat(eficiencia.value);
-    const anchoVal = parseFloat(ancho.value);
-    const velVal = parseFloat(vel.value);
-    const mlPorMin = bcmVal * eficienciaVal * cobertura * anchoVal * velVal;
-    const cargaObjetivo = (sustrato === 'film') ? 4.0 : 3.0;
-    const idealMlMin = cargaObjetivo * anchoVal * velVal;
-    const eje = Math.max(idealMlMin, mlPorMin) * 1.2;
-    chart.data.datasets[0].data = [mlPorMin, idealMlMin];
-    chart.options.scales.y.max = eje;
-    chart.update();
-    detalles.innerHTML = `BCM: ${bcmVal} ml/m²<br>Eficiencia: ${eficienciaVal}<br>Cobertura: ${cobertura.toFixed(2)}<br>Ancho: ${anchoVal} m<br>Velocidad: ${velVal} m/min<br><code>ml/min = ${bcmVal} * ${eficienciaVal} * ${cobertura.toFixed(2)} * ${anchoVal} * ${velVal} = ${mlPorMin.toFixed(2)}</code><br>Ideal: ${idealMlMin.toFixed(2)} ml/min`;
   }
 
   function dibujarTextos() {
@@ -99,32 +76,31 @@ function inicializarSimulacionFlexo() {
     const valBcm = parseFloat(bcm.value);
     const valVel = parseFloat(vel.value);
     const cobertura = datos.cobertura || {};
-    const promedio = (cobertura.C + cobertura.M + cobertura.Y + cobertura.K) / 400 || 0;
+    const promedio =
+      (cobertura.C + cobertura.M + cobertura.Y + cobertura.K) / 400 || 0;
     const minTrama = (datos.trama_minima || 0) / 100;
 
-    // Umbral dinámico de trama débil según LPI
     let umbralTrama = minTrama;
     if (valLpi > 500) {
-      umbralTrama = Math.max(umbralTrama, 0.05); // eliminar tramas muy débiles
+      umbralTrama = Math.max(umbralTrama, 0.05);
     } else if (valLpi < 300) {
-      umbralTrama = Math.min(umbralTrama, 0.03); // permitir tramas muy bajas
+      umbralTrama = Math.min(umbralTrama, 0.03);
     }
 
     const spacing = Math.max(2, (600 / valLpi) * 4);
     const baseRadio = spacing / 2;
     const transferencia = (1 - (valVel - 50) / 250) * (0.5 + promedio);
 
-    // Ganancia de punto según BCM y velocidad
     let ganancia = 1;
     if (valBcm >= 6) {
-      ganancia += 0.15 + ((Math.min(valBcm, 8) - 6) / 2) * 0.05; // 6→15%, 8→20%
+      ganancia += 0.15 + ((Math.min(valBcm, 8) - 6) / 2) * 0.05;
     } else if (valBcm <= 3) {
-      ganancia -= 0.1; // BCM muy bajo reduce el punto
+      ganancia -= 0.1;
     }
     if (valVel < 100) {
-      ganancia += 0.10; // velocidad baja aumenta el punto
+      ganancia += 0.1;
     } else if (valVel > 150 && valBcm <= 3) {
-      ganancia -= 0.05; // velocidad alta con BCM bajo afina
+      ganancia -= 0.05;
     }
 
     ctxTrama.clearRect(0, 0, canvasTrama.width, canvasTrama.height);
@@ -144,17 +120,19 @@ function inicializarSimulacionFlexo() {
         const gray = (r + g + b) / 3;
         const coberturaLocal = 1 - gray / 255;
 
-        // Manejo de pérdida de tramas débiles
         if (coberturaLocal < umbralTrama) {
           if (valLpi > 500) {
-            // tramas muy finas desaparecen
             continue;
           } else if (valLpi < 300) {
-            // mostrar tramas bajas con irregularidad
             const jitterX = x + (Math.random() - 0.5) * spacing * 0.3;
             const jitterY = y + (Math.random() - 0.5) * spacing * 0.3;
-            const radioIrregular = baseRadio * Math.sqrt(Math.max(coberturaLocal, 0.02)) * (0.5 + Math.random() * 0.5) * ganancia;
-            const alphaIrregular = coberturaLocal * (valBcm / 8) * transferencia * 0.5;
+            const radioIrregular =
+              baseRadio *
+              Math.sqrt(Math.max(coberturaLocal, 0.02)) *
+              (0.5 + Math.random() * 0.5) *
+              ganancia;
+            const alphaIrregular =
+              coberturaLocal * (valBcm / 8) * transferencia * 0.5;
             ctxTrama.beginPath();
             ctxTrama.fillStyle = `rgba(0,0,0,${alphaIrregular})`;
             ctxTrama.arc(jitterX, jitterY, radioIrregular, 0, Math.PI * 2);
@@ -165,11 +143,10 @@ function inicializarSimulacionFlexo() {
           }
         }
 
-        // Dibujo normal con ganancia de punto
         const radio = baseRadio * Math.sqrt(coberturaLocal) * ganancia;
         let alpha = coberturaLocal * (valBcm / 8) * transferencia;
         if (valLpi > 500 && coberturaLocal < 0.05) {
-          alpha *= 0.1; // casi invisible
+          alpha *= 0.1;
         }
         ctxTrama.beginPath();
         ctxTrama.fillStyle = `rgba(0,0,0,${alpha})`;
@@ -182,18 +159,82 @@ function inicializarSimulacionFlexo() {
   function iniciar() {
     dibujarTrama();
     dibujarTextos();
-    inicializarGrafico();
-    actualizarCalculo();
   }
 
   img.onload = iniciar;
   lpi.addEventListener('input', dibujarTrama);
-  bcm.addEventListener('input', () => { dibujarTrama(); actualizarCalculo(); });
-  vel.addEventListener('input', () => { dibujarTrama(); actualizarCalculo(); });
-  eficiencia.addEventListener('input', actualizarCalculo);
-  ancho.addEventListener('input', actualizarCalculo);
-  btn.addEventListener('click', () => panel.classList.add('abierto'));
-  cerrar.addEventListener('click', () => panel.classList.remove('abierto'));
+  bcm.addEventListener('input', dibujarTrama);
+  vel.addEventListener('input', dibujarTrama);
+  btn.addEventListener('click', () => modal.classList.add('abierto'));
+  cerrar.addEventListener('click', () => modal.classList.remove('abierto'));
 }
 
-document.addEventListener('DOMContentLoaded', inicializarSimulacionFlexo);
+// --- Bloque de cálculo de transmisión de tinta ---
+function inicializarSimulacionTinta() {
+  const bcm = document.getElementById('tinta-bcm');
+  const eficiencia = document.getElementById('tinta-eficiencia');
+  const ancho = document.getElementById('tinta-ancho');
+  const vel = document.getElementById('tinta-velocidad');
+  const canvasGrafico = document.getElementById('tinta-grafico');
+  const detalles = document.getElementById('tinta-detalles');
+  if (!bcm || !eficiencia || !ancho || !vel || !canvasGrafico || !detalles) return;
+
+  const { cobertura, sustrato } = obtenerDatosBase();
+  const ctxGrafico = canvasGrafico.getContext('2d');
+
+  let chart;
+  function inicializarGrafico() {
+    chart = new Chart(ctxGrafico, {
+      type: 'bar',
+      data: {
+        labels: ['Calculado', 'Ideal'],
+        datasets: [
+          {
+            label: 'ml/min',
+            backgroundColor: ['#36a2eb', '#4caf50'],
+            data: [0, 0]
+          }
+        ]
+      },
+      options: {
+        responsive: false,
+        scales: {
+          y: {
+            beginAtZero: true,
+            title: { display: true, text: 'ml/min' }
+          }
+        }
+      }
+    });
+  }
+
+  function actualizarCalculo() {
+    const bcmVal = parseFloat(bcm.value);
+    const eficienciaVal = parseFloat(eficiencia.value);
+    const anchoVal = parseFloat(ancho.value);
+    const velVal = parseFloat(vel.value);
+    const mlPorMin = bcmVal * eficienciaVal * cobertura * anchoVal * velVal;
+    const cargaObjetivo = sustrato === 'film' ? 4.0 : 3.0;
+    const idealMlMin = cargaObjetivo * anchoVal * velVal;
+    const eje = Math.max(idealMlMin, mlPorMin) * 1.2;
+    chart.data.datasets[0].data = [mlPorMin, idealMlMin];
+    chart.options.scales.y.max = eje;
+    chart.update();
+    detalles.innerHTML =
+      `BCM: ${bcmVal} ml/m²<br>Eficiencia: ${eficienciaVal}<br>Cobertura: ${cobertura.toFixed(
+        2
+      )}<br>Ancho: ${anchoVal} m<br>Velocidad: ${velVal} m/min<br><code>ml/min = ${bcmVal} * ${eficienciaVal} * ${cobertura.toFixed(
+        2
+      )} * ${anchoVal} * ${velVal} = ${mlPorMin.toFixed(
+        2
+      )}</code><br>Ideal: ${idealMlMin.toFixed(2)} ml/min`;
+  }
+
+  inicializarGrafico();
+  actualizarCalculo();
+  bcm.addEventListener('input', actualizarCalculo);
+  eficiencia.addEventListener('input', actualizarCalculo);
+  ancho.addEventListener('input', actualizarCalculo);
+  vel.addEventListener('input', actualizarCalculo);
+}
+

--- a/templates/resultado_flexo.html
+++ b/templates/resultado_flexo.html
@@ -132,23 +132,30 @@
     .warning-icon.tipo-overprint { background: blue; }
     .warning-icon.tipo-borde { background: darkgreen; }
 
-    #panel-simulacion {
+    #simulacion-en-vivo {
+      display: none;
       position: fixed;
       top: 0;
-      right: 0;
-      width: 300px;
+      left: 0;
+      width: 100%;
       height: 100%;
-      background: #fff;
-      box-shadow: -2px 0 5px rgba(0,0,0,0.3);
-      transform: translateX(100%);
-      transition: transform 0.3s;
+      background: rgba(0,0,0,0.5);
       z-index: 10001;
-      padding: 15px;
-      overflow-y: auto;
     }
-    #panel-simulacion.abierto { transform: translateX(0); }
-    #panel-simulacion label { display: block; margin-top: 10px; }
-    #panel-simulacion canvas { width: 100%; border: 1px solid #ccc; margin-top: 10px; }
+    #simulacion-en-vivo.abierto { display: block; }
+    #simulacion-en-vivo .modal-contenido {
+      background: #fff;
+      margin: 5% auto;
+      padding: 15px;
+      width: 90%;
+      max-width: 600px;
+      position: relative;
+    }
+    #simulacion-en-vivo label { display: block; margin-top: 10px; }
+    #simulacion-en-vivo canvas { width: 100%; border: 1px solid #ccc; margin-top: 10px; }
+    #simulacion-tinta { margin-top: 20px; }
+    #simulacion-tinta label { display: block; margin-top: 10px; }
+    #simulacion-tinta canvas { width: 100%; border: 1px solid #ccc; margin-top: 10px; }
   </style>
 </head>
 <body>
@@ -298,21 +305,30 @@
   </script>
   <div id="resumen-diagnostico">{{ resumen|safe }}</div>
   {{ tabla_riesgos|safe }}
+  <div id="simulacion-tinta">
+    <h3>Transmisión de tinta (ml/min)</h3>
+    <label>BCM (ml/m²): <input type="range" id="tinta-bcm" min="1" max="8" step="0.1" value="4"></label>
+    <label>Eficiencia (0-1): <input type="range" id="tinta-eficiencia" min="0" max="1" step="0.01" value="0.30"></label>
+    <label>Ancho (m): <input type="number" id="tinta-ancho" min="0.1" step="0.01" value="0.50"></label>
+    <label>Velocidad (m/min): <input type="range" id="tinta-velocidad" min="50" max="300" value="150"></label>
+    <canvas id="tinta-grafico" width="280" height="200"></canvas>
+    <div id="tinta-detalles"></div>
+  </div>
   <div class="botones">
-    <button id="btn-simulacion-flexo" class="btn" type="button">Simulación Flexo</button>
+    <button id="btn-simulacion-flexo" class="btn" type="button">Ver Simulación en vivo</button>
     <a href="{{ url_for('static', filename=imagen_iconos_web) }}" class="btn" download>⬇ Descargar imagen con advertencias</a>
     <a href="{{ url_for('routes.revision_flexo') }}" class="btn">⬅ Volver a revisar otro diseño</a>
   </div>
-  <div id="panel-simulacion">
-    <button id="cerrar-simulacion" class="btn" type="button">Cerrar ✖</button>
-    <label>Anilox LPI: <input type="range" id="sim-lpi" min="200" max="600" value="400"></label>
-    <label>BCM (ml/m²): <input type="range" id="sim-bcm" min="1" max="8" step="0.1" value="4"></label>
-    <label>Velocidad (m/min): <input type="range" id="sim-velocidad" min="50" max="300" value="150"></label>
-    <label>Eficiencia (0-1): <input type="range" id="sim-eficiencia" min="0" max="1" step="0.01" value="0.30"></label>
-    <label>Ancho (m): <input type="number" id="sim-ancho" min="0.1" step="0.01" value="0.50"></label>
-    <canvas id="sim-canvas" width="280" height="280"></canvas>
-    <canvas id="sim-grafico" width="280" height="200"></canvas>
-    <div id="sim-detalles"></div>
+  <div id="simulacion-en-vivo">
+    <div class="modal-contenido">
+      <button id="cerrar-simulacion" class="btn" type="button">Cerrar ✖</button>
+      <label>Anilox LPI: <input type="range" id="sim-lpi" min="200" max="600" value="400"></label>
+      <label>BCM (ml/m²): <input type="range" id="sim-bcm" min="1" max="8" step="0.1" value="4"></label>
+      <label>Velocidad (m/min): <input type="range" id="sim-velocidad" min="50" max="300" value="150"></label>
+      <div id="sim-canvas-container" style="position:relative;">
+        <canvas id="sim-canvas" width="280" height="280"></canvas>
+      </div>
+    </div>
   </div>
   <script>
     window.diagnosticoFlexo = {{ diagnostico_json | default({}) | tojson }};


### PR DESCRIPTION
## Summary
- Se separó el cálculo de transmisión de tinta en un bloque propio `#simulacion-tinta` con gráfico y detalles.
- Se creó un modal `#simulacion-en-vivo` exclusivo para la vista interactiva de retícula y controles LPI/BCM/Velocidad.
- Se reescribió `simulacion_flexo.js` para manejar de forma independiente la simulación visual y el cálculo de ml/min.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c5106ae6fc8322a5acff433fcde718