### PR TITLE
Remove duplicate ink transmission chart

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -1271,13 +1271,6 @@ def revision_flexo():
                         "Y": round(cobertura_dict.get("Amarillo", 0)),
                         "K": round(cobertura_dict.get("Negro", 0)),
                     },
-                    "trama_minima": analisis_detallado.get("trama_minima", 5),
-                    "resolucion_minima": analisis_detallado.get("resolucion_minima", 0),
-                    "textos_pequenos": [
-                        {"tamano": o.get("tamano"), "color": o.get("color")}
-                        for o in advertencias_overlay
-                        if o.get("tipo") == "texto_pequeno"
-                    ],
                     "bcm": anilox_bcm,
                     "eficiencia": 0.30,
                     "ancho": 0.50,

--- a/static/js/simulacion_flexo.js
+++ b/static/js/simulacion_flexo.js
@@ -1,5 +1,4 @@
 document.addEventListener('DOMContentLoaded', () => {
-  renderizarDiagnostico();
   inicializarSimulacionViva();
 });
 
@@ -13,49 +12,6 @@ function obtenerCobertura(datos) {
   return (c.C + c.M + c.Y + c.K) / 400 || 0;
 }
 
-function renderizarDiagnostico() {
-  const datos = window.diagnosticoFlexo || {};
-  const cobertura = obtenerCobertura(datos);
-  const params = {
-    bcm: datos.bcm || 4,
-    eficiencia: datos.eficiencia || 0.3,
-    cobertura,
-    ancho: datos.ancho || 0.5,
-    velocidad: datos.velocidad || 150,
-  };
-  const mlMin = calcularTransmisionTinta(params);
-  const sustrato = datos.material || 'papel';
-  const cargaObjetivo = sustrato === 'film' ? 4.0 : 3.0;
-  const ideal = parseFloat((cargaObjetivo * params.ancho * params.velocidad).toFixed(2));
-  const ctx = document.getElementById('tinta-grafico').getContext('2d');
-  new Chart(ctx, {
-    type: 'bar',
-    data: {
-      labels: ['Calculado', 'Ideal'],
-      datasets: [
-        {
-          label: 'ml/min',
-          backgroundColor: ['#36a2eb', '#4caf50'],
-          data: [mlMin, ideal],
-        },
-      ],
-    },
-    options: {
-      responsive: false,
-      scales: {
-        y: { beginAtZero: true, max: Math.max(mlMin, ideal) * 1.2 },
-      },
-    },
-  });
-  const detalles = document.getElementById('tinta-detalles');
-  detalles.innerHTML =
-    `BCM: ${params.bcm} ml/m²<br>` +
-    `Eficiencia: ${params.eficiencia}<br>` +
-    `Cobertura: ${cobertura.toFixed(2)}<br>` +
-    `Ancho: ${params.ancho} m<br>` +
-    `Velocidad: ${params.velocidad} m/min<br>` +
-    `<strong>${mlMin} ml/min</strong> (ideal ${ideal} ml/min)`;
-}
 
 function inicializarSimulacionViva() {
   const btn = document.getElementById('btn-simulacion-flexo');

--- a/templates/resultado_flexo.html
+++ b/templates/resultado_flexo.html
@@ -154,9 +154,6 @@
     }
     #simulacion-en-vivo label { display: block; margin-top: 10px; }
     #simulacion-en-vivo canvas { width: 100%; border: 1px solid #ccc; margin-top: 10px; }
-    #simulacion-tinta { margin-top: 20px; }
-    #simulacion-tinta label { display: block; margin-top: 10px; }
-    #simulacion-tinta canvas { width: 100%; border: 1px solid #ccc; margin-top: 10px; }
   </style>
 </head>
 <body>
@@ -306,11 +303,6 @@
   </script>
   <div id="resumen-diagnostico">{{ resumen|safe }}</div>
   {{ tabla_riesgos|safe }}
-  <div id="simulacion-tinta">
-    <h3>Transmisión de tinta (ml/min)</h3>
-    <canvas id="tinta-grafico" width="280" height="200"></canvas>
-    <div id="tinta-detalles"></div>
-  </div>
   <div class="botones">
     <button id="btn-simulacion-flexo" class="btn" type="button">Ver Simulación en vivo</button>
     <a href="{{ url_for('static', filename=imagen_iconos_web) }}" class="btn" download>⬇ Descargar imagen con advertencias</a>
@@ -319,6 +311,7 @@
   <div id="simulacion-en-vivo">
     <div class="modal-contenido">
       <button id="cerrar-simulacion" class="btn" type="button">Cerrar ✖</button>
+      <h3>Transmisión de tinta (ml/min) — Simulación en vivo</h3>
       <label>Anilox LPI: <input type="range" id="sim-lpi" min="200" max="600" value="400"></label>
       <label>BCM (ml/m²): <input type="range" id="sim-bcm" min="1" max="8" step="0.1" value="4"></label>
       <label>Velocidad (m/min): <input type="range" id="sim-velocidad" min="50" max="300" value="150"></label>
@@ -333,7 +326,6 @@
   <script>
     window.diagnosticoFlexo = {{ diagnostico_json | default({}) | tojson }};
   </script>
-  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="{{ url_for('static', filename='js/simulacion_flexo.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Remove server-rendered ink transmission chart from flexo diagnostics page
- Streamline data passed from routes to template for ink simulation
- Rely on live JavaScript simulation for ink transmission calculations

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c51c8e9e688322a6d1e5f0d3c4b4f8