### PR TITLE
Add zoomable modal for advanced simulation

### DIFF
--- a/static/js/simulacion_flexo.js
+++ b/static/js/simulacion_flexo.js
@@ -1,5 +1,6 @@
 document.addEventListener('DOMContentLoaded', () => {
   inicializarSimulacionAvanzada();
+  inicializarModalSimulacion();
 });
 
 function calcularTransmisionTinta({ bcm, eficiencia, cobertura, ancho, velocidad, paso }) {
@@ -112,4 +113,60 @@ function inicializarSimulacionAvanzada() {
   [lpi, bcm, paso, vel].forEach(el => el.addEventListener('input', dibujar));
   actualizarValores();
   if (img.complete) dibujar();
+}
+
+function inicializarModalSimulacion() {
+  const btn = document.getElementById('sim-view-large');
+  const modal = document.getElementById('sim-modal');
+  const modalImg = document.getElementById('sim-modal-img');
+  const closeBtn = document.getElementById('sim-close');
+  if (!btn || !modal || !modalImg || !closeBtn) return;
+
+  let scale = 1;
+  let lastDist = null;
+
+  btn.addEventListener('click', () => {
+    const canvas = document.getElementById('sim-canvas');
+    if (!canvas) return;
+    modalImg.src = canvas.toDataURL('image/png');
+    scale = 1;
+    modalImg.style.transform = 'scale(1)';
+    modal.style.display = 'flex';
+  });
+
+  function cerrar() {
+    modal.style.display = 'none';
+  }
+
+  closeBtn.addEventListener('click', cerrar);
+  modal.addEventListener('click', e => { if (e.target === modal) cerrar(); });
+
+  modalImg.addEventListener('wheel', e => {
+    e.preventDefault();
+    scale += e.deltaY * -0.001;
+    scale = Math.min(Math.max(1, scale), 5);
+    modalImg.style.transform = `scale(${scale})`;
+  });
+
+  modalImg.addEventListener('touchstart', e => {
+    if (e.touches.length === 2) {
+      e.preventDefault();
+      lastDist = dist(e.touches[0], e.touches[1]);
+    }
+  }, { passive: false });
+
+  modalImg.addEventListener('touchmove', e => {
+    if (e.touches.length === 2 && lastDist) {
+      e.preventDefault();
+      const newDist = dist(e.touches[0], e.touches[1]);
+      const factor = newDist / lastDist;
+      scale = Math.min(Math.max(1, scale * factor), 5);
+      lastDist = newDist;
+      modalImg.style.transform = `scale(${scale})`;
+    }
+  }, { passive: false });
+
+  function dist(t1, t2) {
+    return Math.hypot(t1.clientX - t2.clientX, t1.clientY - t2.clientY);
+  }
 }

--- a/templates/resultado_flexo.html
+++ b/templates/resultado_flexo.html
@@ -144,6 +144,53 @@
     #simulacion-avanzada h3 { text-align: center; }
     #simulacion-avanzada label { display: block; margin-top: 10px; }
     #simulacion-avanzada canvas { width: 100%; border: 1px solid #ccc; margin-top: 15px; }
+
+    /* Modal para ver simulación en grande */
+    #sim-modal {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: rgba(0, 0, 0, 0.6);
+      display: none;
+      align-items: center;
+      justify-content: center;
+      z-index: 1000;
+    }
+    #sim-modal .modal-content {
+      background: #fff;
+      position: relative;
+      padding: 10px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      max-width: 80%;
+      max-height: 80%;
+      width: 100%;
+      overflow: auto;
+    }
+    #sim-modal img {
+      width: 100%;
+      height: auto;
+      transform-origin: center;
+      touch-action: none;
+    }
+    #sim-close {
+      position: absolute;
+      top: 5px;
+      right: 10px;
+      background: none;
+      border: none;
+      font-size: 1.5rem;
+      cursor: pointer;
+    }
+    @media (max-width: 768px) {
+      #sim-modal .modal-content {
+        max-width: 100%;
+        max-height: 100%;
+      }
+    }
   </style>
 </head>
 <body>
@@ -319,8 +366,16 @@
       <span id="sim-vel-val">{{ diag.get('velocidad', diag.get('velocidad_impresion', 150)) }} m/min</span>
     </label>
     <canvas id="sim-canvas" width="280" height="280"></canvas>
+    <button id="sim-view-large" class="btn" type="button">🔍 Ver simulación en grande</button>
     <div id="sim-ml"></div>
   </section>
+
+  <div id="sim-modal">
+    <div class="modal-content">
+      <button id="sim-close">❌</button>
+      <img id="sim-modal-img" alt="Simulación en grande" />
+    </div>
+  </div>
 
   <div class="botones">
     <a href="{{ url_for('static', filename=imagen_iconos_web) }}" class="btn" download>⬇ Descargar imagen con advertencias</a>


### PR DESCRIPTION
## Summary
- add CSS and markup for responsive modal to view advanced simulation at larger size
- provide zoom via mouse wheel and pinch gestures
- add button to open modal using current simulation canvas

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5ec86ec348322b7ba77821bb572ec