### PR TITLE
Reorganiza flujo de revisión flexográfica

### DIFF
--- a/static/js/simulacion_flexo.js
+++ b/static/js/simulacion_flexo.js
@@ -19,24 +19,24 @@ function obtenerCobertura(datos) {
 function inicializarSimulacionAvanzada() {
   const lpi = document.getElementById('sim-lpi');
   const bcm = document.getElementById('sim-bcm');
-  const paso = document.getElementById('sim-paso');
   const vel = document.getElementById('sim-velocidad');
+  const cob = document.getElementById('sim-cobertura');
   const lpiVal = document.getElementById('sim-lpi-val');
   const bcmVal = document.getElementById('sim-bcm-val');
-  const pasoVal = document.getElementById('sim-paso-val');
   const velVal = document.getElementById('sim-vel-val');
+  const cobVal = document.getElementById('sim-cobertura-val');
   const canvas = document.getElementById('sim-canvas');
   const resultado = document.getElementById('sim-ml');
-  if (!lpi || !bcm || !paso || !vel || !canvas || !resultado || !lpiVal || !bcmVal || !pasoVal || !velVal) {
+  if (!lpi || !bcm || !vel || !cob || !canvas || !resultado || !lpiVal || !bcmVal || !velVal || !cobVal) {
     return;
   }
 
   const datos = window.diagnosticoFlexo || {};
-  lpi.value = datos.anilox_lpi ?? datos.lpi ?? lpi.value;
-  bcm.value = datos.anilox_bcm ?? datos.bcm ?? bcm.value;
-  paso.value = datos.paso_cilindro ?? datos.paso ?? paso.value;
-  vel.value = datos.velocidad ?? datos.velocidad_impresion ?? vel.value;
-  const coberturaBase = obtenerCobertura(datos);
+  lpi.value = datos.anilox_lpi ?? datos.lpi ?? lpi.value ?? 360;
+  bcm.value = datos.anilox_bcm ?? datos.bcm ?? bcm.value ?? 4;
+  vel.value = datos.velocidad ?? datos.velocidad_impresion ?? vel.value ?? 150;
+  cob.value = datos.cobertura_estimada ?? Math.round(obtenerCobertura(datos) * 100) || 25;
+  const paso = datos.paso_cilindro ?? datos.paso ?? 330;
   const eficiencia = datos.eficiencia || 0.30;
   const ancho = datos.ancho || 0.50;
   const ctx = canvas.getContext('2d');
@@ -46,8 +46,8 @@ function inicializarSimulacionAvanzada() {
   function actualizarValores() {
     lpiVal.textContent = `${lpi.value} lpi`;
     bcmVal.textContent = `${bcm.value} cm³/m²`;
-    pasoVal.textContent = `${paso.value} mm`;
     velVal.textContent = `${vel.value} m/min`;
+    cobVal.textContent = `${cob.value} %`;
   }
 
   function dibujar() {
@@ -93,10 +93,10 @@ function inicializarSimulacionAvanzada() {
 
     const params = {
       bcm: parseFloat(bcm.value),
-      paso: parseFloat(paso.value),
+      paso,
       velocidad: parseFloat(vel.value),
       eficiencia,
-      cobertura: coberturaBase,
+      cobertura: parseFloat(cob.value) / 100,
       ancho,
     };
     const mlMin = calcularTransmisionTinta(params);
@@ -110,7 +110,7 @@ function inicializarSimulacionAvanzada() {
     img.src = baseImg.src;
   }
 
-  [lpi, bcm, paso, vel].forEach(el => el.addEventListener('input', dibujar));
+  [lpi, bcm, vel, cob].forEach(el => el.addEventListener('input', dibujar));
   actualizarValores();
   if (img.complete) dibujar();
 }

--- a/templates/resultado_flexo.html
+++ b/templates/resultado_flexo.html
@@ -344,7 +344,7 @@
   {{ tabla_riesgos|safe }}
 
   <section id="simulacion-avanzada">
-    <h3>Simulación avanzada de impresión</h3>
+    <h3>⚙️ Simulación Avanzada de Impresión</h3>
     <label>
       Lineatura del Anilox (LPI):
       <input type="range" id="sim-lpi" min="80" max="600" value="{{ diag.get('anilox_lpi', diag.get('lpi', 360)) }}">
@@ -356,17 +356,17 @@
       <span id="sim-bcm-val">{{ diag.get('anilox_bcm', diag.get('bcm', 4)) }} cm³/m²</span>
     </label>
     <label>
-      Paso del cilindro (mm):
-      <input type="range" id="sim-paso" min="250" max="1200" step="1" value="{{ diag.get('paso_cilindro', diag.get('paso', 330)) }}">
-      <span id="sim-paso-val">{{ diag.get('paso_cilindro', diag.get('paso', 330)) }} mm</span>
-    </label>
-    <label>
       Velocidad estimada de impresión (m/min):
       <input type="range" id="sim-velocidad" min="50" max="500" value="{{ diag.get('velocidad', diag.get('velocidad_impresion', 150)) }}">
       <span id="sim-vel-val">{{ diag.get('velocidad', diag.get('velocidad_impresion', 150)) }} m/min</span>
     </label>
+    <label>
+      Cobertura estimada (%):
+      <input type="range" id="sim-cobertura" min="0" max="100" value="{{ diag.get('cobertura_estimada', 25) }}">
+      <span id="sim-cobertura-val">{{ diag.get('cobertura_estimada', 25) }} %</span>
+    </label>
     <canvas id="sim-canvas" width="280" height="280"></canvas>
-    <button id="sim-view-large" class="btn" type="button">🔍 Ver simulación en grande</button>
+    <button id="sim-view-large" class="btn" type="button">🔍 Ver imagen completa</button>
     <div id="sim-ml"></div>
   </section>
 

--- a/templates/revision_flexo.html
+++ b/templates/revision_flexo.html
@@ -179,23 +179,7 @@
         </div>
 
         <div class="form-block">
-          <h2>🌀 Parámetros del anilox</h2>
-          <label for="anilox_lpi">LPI del anilox
-            <span class="tooltip-icon">❓
-              <span class="tooltip-text">Líneas por pulgada del rodillo anilox.</span>
-            </span>
-          </label>
-          <input class="input-field" type="number" name="anilox_lpi" placeholder="Ej: 360 lpi">
-          <label for="anilox_bcm">BCM del anilox
-            <span class="tooltip-icon">❓
-              <span class="tooltip-text">Volumen de celdas en cm³/m².</span>
-            </span>
-          </label>
-          <input class="input-field" type="number" step="0.1" name="anilox_bcm" placeholder="Ej: 4.0">
-        </div>
-
-        <div class="form-block">
-          <h2>⚙️ Condiciones de impresión</h2>
+          <h2>📦 Material de impresión</h2>
           <label for="material">Material de impresión
             <span class="tooltip-icon">❓
               <span class="tooltip-text">Sustrato donde se imprimirá.</span>
@@ -205,23 +189,11 @@
             <option value="film">Film</option>
             <option value="papel">Papel</option>
             <option value="carton">Cartón</option>
-            <option value="etiqueta adhesiva">Etiqueta adhesiva</option>
+            <option value="adhesivo">Adhesivo</option>
           </select>
-          <label for="velocidad">Velocidad de impresión (m/min)
-            <span class="tooltip-icon">❓
-              <span class="tooltip-text">Velocidad estimada de la prensa.</span>
-            </span>
-          </label>
-          <input class="input-field" type="number" name="velocidad" placeholder="Ej: 150">
-          <label for="cobertura">Cobertura estimada (%)
-            <span class="tooltip-icon">❓
-              <span class="tooltip-text">Promedio de cobertura de tinta.</span>
-            </span>
-          </label>
-          <input class="input-field" type="number" name="cobertura" placeholder="Ej: 25">
         </div>
 
-        <button class="btn" type="submit"><span>🔎</span> Revisar diseño</button>
+        <button class="btn" type="submit"><span>🔍</span> Revisar diseño</button>
       </form>
 
       <form id="vista-previa-form" action="/vista_previa_tecnica" method="POST">


### PR DESCRIPTION
## Resumen
- Simplifica el formulario inicial a solo PDF y material
- Crea bloque de simulación avanzada con sliders y modal
- Ajusta rutas para usar valores por defecto y nueva vista de resultados

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c602855684832289d94bdbe365bb89