### PR TITLE
Normaliza alias para materiales en montaje flexo

### DIFF
--- a/montaje_flexo.py
+++ b/montaje_flexo.py
@@ -661,7 +661,17 @@ def revisar_diseño_flexo(
 
     diagnostico_material = []
     material_norm = material.lower().strip()
-    if material_norm == "film":
+    # Normalizar alias de materiales
+    material_alias = {
+        "adhesivo": "etiqueta adhesiva",
+        "etiqueta adhesiva": "etiqueta adhesiva",
+        "film": "película",
+        "pelicula": "película",
+        "carton": "cartón",
+    }
+    material_norm = material_alias.get(material_norm, material_norm)
+
+    if material_norm in ("film", "película"):
         negro = metricas_cobertura["cobertura_promedio"].get("Negro", 0) if metricas_cobertura else 0
         if negro > 50:
             diagnostico_material.append(


### PR DESCRIPTION
## Summary
- Normaliza los nombres de materiales en `montaje_flexo` para aceptar alias como *adhesivo* → *etiqueta adhesiva*
- Deja un diccionario preparado para futuros alias como film/película o carton/cartón

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c609864e988322be3907b477e8d814