### PR TITLE
Normalize material aliases for flexo analysis

### DIFF
--- a/advertencias_disenio.py
+++ b/advertencias_disenio.py
@@ -2,7 +2,7 @@ import fitz
 from typing import List, Dict, Any
 
 from diagnostico_flexo import filtrar_objetos_sistema, consolidar_advertencias
-from utils import convertir_pts_a_mm
+from utils import convertir_pts_a_mm, normalizar_material
 
 PT_PER_MM = 72 / 25.4
 
@@ -67,7 +67,8 @@ def verificar_textos_pequenos(contenido: Dict[str, Any]) -> tuple[List[str], Lis
 
 def verificar_lineas_finas_v2(page: fitz.Page, material: str) -> tuple[List[str], List[Dict[str, Any]]]:
     mins = {"film": 0.12, "papel": 0.20, "etiqueta adhesiva": 0.18}
-    thr = mins.get((material or "").strip().lower(), 0.20)
+    mat_norm = normalizar_material(material)
+    thr = mins.get(mat_norm, 0.20)
     min_detectada = None
     n_riesgo = 0
     overlay: List[Dict[str, Any]] = []

--- a/reporte_tecnico.py
+++ b/reporte_tecnico.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 from typing import List, Dict, Any
 
+from utils import normalizar_material
+
 
 def _card(titulo: str, items_html: List[str] | str) -> str:
     """Envuelve una lista de elementos en un contenedor con título."""
@@ -17,7 +19,7 @@ def resumen_cobertura_tac(metricas: Dict[str, Any], material: str) -> List[str]:
     tac_p95 = metricas["tac_p95"]
     tac_max = metricas["tac_max"]
     limites = {"film": 320, "papel": 300, "etiqueta adhesiva": 280}
-    mat = (material or "").strip().lower()
+    mat = normalizar_material(material)
     lim = limites.get(mat, 300)
     estado = "ok" if tac_p95 <= lim else ("warn" if tac_p95 <= lim + 20 else "error")
     icon = {"ok": "✔️", "warn": "⚠️", "error": "❌"}[estado]

--- a/routes.py
+++ b/routes.py
@@ -31,6 +31,7 @@ from utils import (
     corregir_sangrado,
     redimensionar_pdf,
     calcular_etiquetas_por_fila,
+    normalizar_material,
 )
 from simulacion import generar_preview_interactivo, generar_preview_virtual
 from ia_sugerencias import chat_completion, transcribir_audio
@@ -1211,7 +1212,7 @@ def revision_flexo():
     if request.method == "POST":
         try:
             archivo = request.files.get("archivo_revision")
-            material = request.form.get("material", "")
+            material = normalizar_material(request.form.get("material", ""))
 
             # Valores predeterminados para la simulación avanzada
             anilox_lpi = 360

--- a/utils.py
+++ b/utils.py
@@ -3,6 +3,7 @@ from PIL import Image
 import numpy as np
 from io import BytesIO
 import math
+from typing import Dict
 
 
 def corregir_sangrado(input_path, output_path):
@@ -130,3 +131,31 @@ def verificar_dimensiones(
             f"<span class='icono warn'>⚠️</span> El ancho del diseño (<b>{ancho_mm} mm</b>) podría exceder el ancho útil de la máquina. Verificar configuración."
         )
     return advertencias
+
+
+# Mapeo centralizado de alias de materiales a sus valores estándar
+MATERIAL_ALIAS: Dict[str, str] = {
+    "película": "film",
+    "pelicula": "film",
+    "film": "film",
+    "adhesivo": "etiqueta adhesiva",
+    "etiqueta": "etiqueta adhesiva",
+    "etiqueta adhesiva": "etiqueta adhesiva",
+    "carton": "cartón",
+    "cartón": "cartón",
+}
+
+
+def normalizar_material(material: str) -> str:
+    """Devuelve el nombre estándar del material.
+
+    Se utiliza un diccionario de alias para unificar las distintas formas en que
+    puede recibirse el dato desde el formulario, evitando duplicar claves en
+    tablas internas. El resultado siempre está en minúsculas para facilitar las
+    comparaciones.
+    """
+
+    if not material:
+        return ""
+    mat = material.lower().strip()
+    return MATERIAL_ALIAS.get(mat, mat)


### PR DESCRIPTION
## Summary
- Centralize material alias mapping and provide `normalizar_material` helper.
- Normalize form material values before processing ink factors and warnings.
- Use canonical material names throughout flexo diagnostics and reporting.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c60ff06054832290e5e28824493e3f