### PR TITLE
Simplify flexo revision form and defaults

### DIFF
--- a/templates/revision_flexo.html
+++ b/templates/revision_flexo.html
@@ -185,11 +185,11 @@
               <span class="tooltip-text">Sustrato donde se imprimirá.</span>
             </span>
           </label>
-          <select name="material">
+          <select name="material" required>
             <option value="film">Film</option>
             <option value="papel">Papel</option>
             <option value="carton">Cartón</option>
-            <option value="adhesivo">Adhesivo</option>
+            <option value="etiqueta adhesiva">Etiqueta adhesiva</option>
           </select>
         </div>
 


### PR DESCRIPTION
## Summary
- Simplify flexo revision form to only require PDF and material, with an updated "Etiqueta adhesiva" option
- Handle default LPI, BCM and speed values in `/revision` while allowing advanced overrides
- Automatically compute ink coverage from the PDF and feed the values into diagnostics and simulation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c617eba8b08322b89cffed77e488e5