### PR TITLE
Fix Flexo revision form field bindings

### DIFF
--- a/templates/revision_flexo.html
+++ b/templates/revision_flexo.html
@@ -175,7 +175,7 @@
               <span class="tooltip-text">Carga el archivo final en formato PDF.</span>
             </span>
           </label>
-          <input class="input-field" type="file" name="archivo_revision" accept="application/pdf" required>
+          <input class="input-field" id="archivo_revision" type="file" name="archivo_revision" accept="application/pdf" required>
         </div>
 
         <div class="form-block">
@@ -185,7 +185,7 @@
               <span class="tooltip-text">Sustrato donde se imprimirá.</span>
             </span>
           </label>
-          <select name="material" required>
+          <select id="material" name="material" required>
             <option value="film">Film</option>
             <option value="papel">Papel</option>
             <option value="carton">Cartón</option>


### PR DESCRIPTION
## Summary
- ensure revision form posts PDF and material fields correctly with proper IDs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c61e368a808322b7438786a18a4880