### PR TITLE
Restore simplified flexo revision flow

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -1214,20 +1214,25 @@ def revision_flexo():
             archivo = request.files.get("archivo_revision")
             material = normalizar_material(request.form.get("material", ""))
 
-            # Valores predeterminados (sobrescribibles en modo avanzado)
+            # Valores predeterminados para el modo simplificado
             paso_mm = 330
+            anilox_lpi = 360
+            anilox_bcm = 4.0
+            velocidad = 150.0
+
+            # Permite sobrescribir en un futuro con campos opcionales
             try:
-                anilox_lpi = float(request.form.get("anilox_lpi", 360) or 360)
+                anilox_lpi = float(request.form.get("anilox_lpi") or anilox_lpi)
             except (TypeError, ValueError):
-                anilox_lpi = 360
+                pass
             try:
-                anilox_bcm = float(request.form.get("anilox_bcm", 4.0) or 4.0)
+                anilox_bcm = float(request.form.get("anilox_bcm") or anilox_bcm)
             except (TypeError, ValueError):
-                anilox_bcm = 4.0
+                pass
             try:
-                velocidad = float(request.form.get("velocidad", 150.0) or 150.0)
+                velocidad = float(request.form.get("velocidad") or velocidad)
             except (TypeError, ValueError):
-                velocidad = 150.0
+                pass
 
             if archivo and archivo.filename.lower().endswith(".pdf") and material:
                 # Siempre guardamos el PDF con un nombre fijo para evitar usar uno previo.
@@ -1236,6 +1241,7 @@ def revision_flexo():
                 if os.path.exists(path):
                     os.remove(path)
                 archivo.save(path)
+                pdf_rel = os.path.join("uploads", filename)
 
                 # Guardamos la ruta en sesión para reutilizarla en la vista previa
                 session["archivo_pdf"] = path
@@ -1279,6 +1285,8 @@ def revision_flexo():
                 )
 
                 diagnostico_json = {
+                    "archivo": filename,
+                    "pdf_path": pdf_rel,
                     "cobertura": cobertura_json,
                     "cobertura_estimada": cobertura_total,
                     "bcm": anilox_bcm,
@@ -1315,6 +1323,7 @@ def revision_flexo():
                     "tabla_riesgos": tabla_riesgos,
                     "imagen_path_web": imagen_rel,
                     "imagen_iconos_web": imagen_iconos_rel,
+                    "pdf_path_web": pdf_rel,
                     "texto": texto,
                     "analisis": analisis_detallado,
                     "advertencias_iconos": advertencias_iconos,
@@ -1341,6 +1350,7 @@ def resultado_flexo():
         tabla_riesgos=datos.get("tabla_riesgos", ""),
         imagen_path_web=datos.get("imagen_path_web", ""),
         imagen_iconos_web=datos.get("imagen_iconos_web", ""),
+        pdf_path_web=datos.get("pdf_path_web", ""),
         texto=datos.get("texto", ""),
         analisis=datos.get("analisis", {}),
         advertencias_iconos=datos.get("advertencias_iconos", []),

--- a/static/js/flexo_simulation.js
+++ b/static/js/flexo_simulation.js
@@ -42,9 +42,9 @@ function inicializarSimulacionAvanzada() {
   }
 
   const datos = window.diagnosticoFlexo || {};
-  lpi.value = datos.lpi ?? lpi.value ?? 360;
-  bcm.value = datos.bcm ?? bcm.value ?? 4;
-  vel.value = datos.velocidad ?? datos.velocidad_impresion ?? vel.value ?? 150;
+  lpi.value = datos.lpi ?? 360;
+  bcm.value = datos.bcm ?? 4;
+  vel.value = datos.velocidad ?? datos.velocidad_impresion ?? 150;
   cob.value = datos.cobertura_estimada ?? Math.round(obtenerCobertura(datos) * 100) || 25;
   const paso = datos.paso_cilindro ?? datos.paso ?? 330;
   const eficiencia = datos.eficiencia || 0.30;

--- a/templates/resultado_flexo.html
+++ b/templates/resultado_flexo.html
@@ -199,6 +199,13 @@
     <div id="overlay-markers"></div>
     <div id="tooltip" class="tooltip"></div>
   </div>
+  {% if pdf_path_web %}
+  <div style="text-align:center;margin-top:20px;">
+    <object data="{{ url_for('static', filename=pdf_path_web) }}" type="application/pdf" width="100%" height="600px">
+      <p>Tu navegador no puede mostrar PDFs. <a href="{{ url_for('static', filename=pdf_path_web) }}">Descargar PDF</a>.</p>
+    </object>
+  </div>
+  {% endif %}
   <ul id="lista-advertencias">
     {% set tipo_clases = {
       'texto_pequeno': 'tipo-texto',

--- a/templates/revision_flexo.html
+++ b/templates/revision_flexo.html
@@ -167,7 +167,7 @@
     <div class="card-form">
       <h1>🔍 Revisión previa al envío a clichés</h1>
 
-      <form action="/revision" method="POST" enctype="multipart/form-data">
+      <form action="{{ url_for('routes.revision_flexo') }}" method="POST" enctype="multipart/form-data">
         <div class="form-block">
           <h2>📂 Archivo del diseño</h2>
           <label for="archivo_revision">Archivo PDF del diseño
@@ -196,7 +196,7 @@
         <button class="btn" type="submit"><span>🔍</span> Revisar diseño</button>
       </form>
 
-      <form id="vista-previa-form" action="/vista_previa_tecnica" method="POST">
+      <form id="vista-previa-form" action="{{ url_for('routes.vista_previa_tecnica') }}" method="POST">
         <input type="hidden" name="archivo_guardado" id="archivo_guardado" value="{{ session.get('archivo_pdf', '') }}">
         <button id="vista-previa-btn" class="btn" type="submit"><span>📊</span> Vista previa técnica</button>
       </form>
@@ -219,13 +219,13 @@
             <img src="data:image/png;base64,{{ grafico_tinta }}" alt="Gráfico de tinta"/>
           </div>
         {% endif %}
-        <form action="/sugerencia_ia" method="POST">
+        <form action="{{ url_for('routes.sugerencia_ia') }}" method="POST">
           <input type="hidden" name="diagnostico_texto_b64" value="{{ diagnostico_texto_b64 }}">
           <input type="hidden" name="resultado_revision_b64" value="{{ resultado_revision_b64 }}">
           <input type="hidden" name="grafico_tinta" value="{{ grafico_tinta }}">
           <button class="btn" type="submit">🧠 Obtener sugerencia IA</button>
         </form>
-        <form action="/sugerencia_produccion" method="POST">
+        <form action="{{ url_for('routes.sugerencia_produccion') }}" method="POST">
           <input type="hidden" name="diagnostico_texto_b64" value="{{ diagnostico_texto_b64 }}">
           <input type="hidden" name="resultado_revision_b64" value="{{ resultado_revision_b64 }}">
           <input type="hidden" name="grafico_tinta" value="{{ grafico_tinta }}">


### PR DESCRIPTION
## Summary
- Ensure /revision route handles simplified form, sets default flexo params and stores uploaded PDF for results
- Render result view with PDF preview and dynamic paths
- Simplify flexo JS to rely solely on backend-calculated values

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6262e0bb8832297567e9776a325e9