### PR TITLE
Simplify flexo revision workflow

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -140,6 +140,7 @@ MATERIAL_ALIAS: Dict[str, str] = {
     "film": "film",
     "adhesivo": "etiqueta adhesiva",
     "etiqueta": "etiqueta adhesiva",
+    "etiqueta_adhesiva": "etiqueta adhesiva",
     "etiqueta adhesiva": "etiqueta adhesiva",
     "carton": "cartón",
     "cartón": "cartón",
@@ -157,5 +158,5 @@ def normalizar_material(material: str) -> str:
 
     if not material:
         return ""
-    mat = material.lower().strip()
+    mat = material.lower().strip().replace("_", " ")
     return MATERIAL_ALIAS.get(mat, mat)


### PR DESCRIPTION
## Summary
- Default flexographic revision now accepts only PDF and material, assigning safe defaults for LPI, BCM, speed and coverage.
- Material normalization handles underscores and more aliases like `etiqueta_adhesiva`.
- Added PDF integrity checks before processing and only expose optional diagnostics when provided.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c62a04bb1c8322868ca2d43a76e597