### PR TITLE
feat: make flexo simulation interactive

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -1379,6 +1379,7 @@ def revision():
     return render_template(
         "resultado_flexo.html",
         **resultado_data,
+        revision_id=revision_id,
     )
 
 
@@ -1402,7 +1403,22 @@ def resultado_flexo():
             "warning",
         )
         return redirect(url_for("revision"))
-    return render_template("resultado_flexo.html", **datos)
+    return render_template("resultado_flexo.html", **datos, revision_id=revision_id)
+
+
+@routes_bp.route("/guardar_simulacion/<revision_id>", methods=["POST"])
+def guardar_simulacion(revision_id):
+    """Guarda la imagen de la simulación enviada desde el frontend."""
+    img_file = request.files.get("image")
+    if not img_file:
+        return jsonify({"error": "No se recibió imagen"}), 400
+    sim_dir = os.path.join(current_app.static_folder, "simulaciones")
+    os.makedirs(sim_dir, exist_ok=True)
+    filename = f"sim_{revision_id}.png"
+    save_path = os.path.join(sim_dir, filename)
+    img_file.save(save_path)
+    rel_path = os.path.relpath(save_path, current_app.static_folder)
+    return jsonify({"path": rel_path})
 
 
 @routes_bp.route("/vista_previa_tecnica", methods=["POST"])

--- a/templates/resultado_flexo.html
+++ b/templates/resultado_flexo.html
@@ -143,7 +143,12 @@
     }
     #simulacion-avanzada h3 { text-align: center; }
     #simulacion-avanzada label { display: block; margin-top: 10px; }
-    #simulacion-avanzada canvas { width: 100%; border: 1px solid #ccc; margin-top: 15px; }
+    #sim-canvas {
+      max-width: 100%;
+      height: auto;
+      border: 1px solid #ccc;
+      margin-top: 15px;
+    }
 
     /* Modal para ver simulación en grande */
     #sim-modal {
@@ -386,12 +391,8 @@
       <input type="range" id="sim-cobertura" min="0" max="100" value="{{ cob_in if cob_in is not none else 25 }}">
       <span id="sim-cobertura-val">{{ cob_in if cob_in is not none else '(calculado en diagnóstico)' }}{% if cob_in is not none %} %{% endif %}</span>
     </label>
-    <canvas id="sim-canvas" width="280" height="280" style="display:none;"></canvas>
-    {% if sim_img_web %}
-    <img id="sim-output" src="{{ url_for('static', filename=sim_img_web) }}" alt="Simulación" />
-    {% else %}
-    <img id="sim-output" alt="Simulación" />
-    {% endif %}
+    <canvas id="sim-canvas" width="280" height="280"></canvas>
+    <button id="sim-save" class="btn" type="button">🖼️ Generar PNG final</button>
     <button id="sim-view-large" class="btn" type="button">🔍 Ver imagen completa</button>
     <div id="sim-ml"></div>
   </section>
@@ -409,6 +410,7 @@
   </div>
   <script>
     window.diagnosticoFlexo = {{ diagnostico_json | default({}) | tojson }};
+    window.revisionId = "{{ revision_id or '' }}";
   </script>
   <script src="{{ url_for('static', filename='js/flexo_simulation.js') }}"></script>
 </body>


### PR DESCRIPTION
## Summary
- replace static PNG with responsive `<canvas>` in flexo results view
- redraw simulation live from slider input and allow exporting final PNG
- add backend endpoint to store generated simulation images

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c64537e4bc8322a4d23c977c6abb34