### PR TITLE
Fix flexo simulation preview and export

### DIFF
--- a/templates/resultado_flexo.html
+++ b/templates/resultado_flexo.html
@@ -144,55 +144,15 @@
     #simulacion-avanzada { min-height: 300px; }
     #simulacion-avanzada h3 { text-align: center; }
     #simulacion-avanzada label { display: block; margin-top: 10px; }
-    #sim-canvas{max-width:100%;height:auto;background:#eef7ff;display:block;min-width:300px;min-height:200px}
-    #sim-container{min-height:260px}
-
-    /* Modal para ver simulación en grande */
-    #sim-modal {
-      position: fixed;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      background: rgba(0, 0, 0, 0.6);
-      display: none;
-      align-items: center;
-      justify-content: center;
-      z-index: 1000;
-    }
-    #sim-modal .modal-content {
-      background: #fff;
-      position: relative;
-      padding: 10px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      max-width: 80%;
-      max-height: 80%;
-      width: 100%;
-      overflow: auto;
-    }
-    #sim-modal img {
-      width: 100%;
+    #sim-canvas {
+      max-width: 100%;
       height: auto;
-      transform-origin: center;
-      touch-action: none;
+      background: #eef7ff;
+      display: block;
+      min-width: 300px;
+      min-height: 150px;
     }
-    #sim-close {
-      position: absolute;
-      top: 5px;
-      right: 10px;
-      background: none;
-      border: none;
-      font-size: 1.5rem;
-      cursor: pointer;
-    }
-    @media (max-width: 768px) {
-      #sim-modal .modal-content {
-        max-width: 100%;
-        max-height: 100%;
-      }
-    }
+    #sim-container { min-height: 260px; }
   </style>
 </head>
 <body>
@@ -391,20 +351,13 @@
       <span id="cov_val">{{ (cob_in if cob_in is not none else 25) }} % {% if cob_in is not none %}(calculado en diagnóstico){% else %}(predeterminado){% endif %}</span>
     </label>
     <div id="sim-container">
-      <canvas id="sim-canvas" width="800" height="450"></canvas>
+      <canvas id="sim-canvas" width="300" height="150"></canvas>
       <pre id="sim-debug" style="display:none"></pre>
     </div>
     <button id="sim-save" class="btn" type="button">🖼️ Generar PNG final</button>
-    <button id="sim-view-large" class="btn" type="button">🔍 Ver imagen completa</button>
+    <a id="sim-view" class="btn" href="{{ url_for('static', filename=sim_img_web) }}" target="_blank" rel="noopener">🔍 Ver imagen completa</a>
     <div id="sim-ml"></div>
   </section>
-
-  <div id="sim-modal">
-    <div class="modal-content">
-      <button id="sim-close">❌</button>
-      <img id="sim-modal-img" alt="Simulación en grande" />
-    </div>
-  </div>
 
   <div class="botones">
     <a href="{{ url_for('static', filename=imagen_iconos_web) }}" class="btn" download>⬇ Descargar imagen con advertencias</a>
@@ -413,7 +366,8 @@
   <script>
     window.diagnosticoFlexo = {{ diagnostico_json | default({}) | tojson }};
     window.revisionId = "{{ revision_id or '' }}";
+    window.diagImg = "{{ url_for('static', filename=diag_img_web) if diag_img_web else '' }}";
   </script>
-  <script src="{{ url_for('static', filename='js/flexo_simulation.js') }}?v=2" defer></script>
+  <script src="{{ url_for('static', filename='js/flexo_simulation.js') }}?v=3" defer></script>
 </body>
 </html>

--- a/tests/test_resultado_flexo_template.py
+++ b/tests/test_resultado_flexo_template.py
@@ -20,5 +20,6 @@ def test_default_warning_message_in_template():
                 tabla_riesgos='',
                 imagen_iconos_web='dummy.png',
                 sim_img_web='simulaciones/sim_dummy.png',
+                diag_img_web='dummy.png',
             )
     assert 'Advertencia sin descripción detallada.' in html


### PR DESCRIPTION
## Summary
- persist diagnostic preview per revision and expose `diag_img_web`
- rebuild simulation frontend to load base diagnostic image and resize canvas responsively
- support exporting simulation PNG via `/simulacion/exportar/<revision_id>` and update link

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c65ea13efc83228a22fe9effbd8e9b