### PR TITLE
Reutilizar imagen de diagnóstico en simulación flexo

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -1376,7 +1376,10 @@ def revision():
             "advertencias_iconos": advertencias_iconos,
             "diagnostico_json": diagnostico_json,
             "sim_img_web": sim_rel,
-            "diag_img_web": diag_rel,
+            # Usar la imagen de diagnóstico con advertencias como base de la simulación
+            # avanzada para que el canvas cargue la misma vista que vio el usuario
+            # durante el análisis.
+            "diag_img_web": imagen_iconos_rel,
         }
 
         diag_json_path = os.path.join(rev_dir, "diag.json")

--- a/static/js/flexo_simulation.js
+++ b/static/js/flexo_simulation.js
@@ -68,7 +68,13 @@ function inicializarSimulacionAvanzada() {
 
   const img = new Image();
   img.crossOrigin = 'anonymous';
-  const diagUrl = window.diagImg;
+  // Intentar reutilizar la imagen del diagnóstico con advertencias.  Si no se
+  // proporciona explícitamente, buscarla en uploads/<revision_id>.
+  const diagUrl =
+    window.diagImg ||
+    (window.revisionId
+      ? `/static/uploads/${window.revisionId}/diagnostico_iconos.png`
+      : null);
   if (diagUrl) {
     img.onload = () => {
       if (DEBUG) console.log('[SIM] imagen base cargada');
@@ -103,20 +109,17 @@ function inicializarSimulacionAvanzada() {
   }
 
   function drawBasePattern() {
-    ctx.fillStyle = '#eef7ff';
+    // Patron de puntos como fondo de reserva para que el canvas nunca quede vacío
+    ctx.fillStyle = '#fff';
     ctx.fillRect(0, 0, canvas.width, canvas.height);
-    ctx.strokeStyle = '#ccc';
-    for (let x = 0; x < canvas.width; x += 25) {
-      ctx.beginPath();
-      ctx.moveTo(x, 0);
-      ctx.lineTo(x, canvas.height);
-      ctx.stroke();
-    }
-    for (let y = 0; y < canvas.height; y += 25) {
-      ctx.beginPath();
-      ctx.moveTo(0, y);
-      ctx.lineTo(canvas.width, y);
-      ctx.stroke();
+    ctx.fillStyle = '#ccc';
+    const spacing = 20;
+    for (let y = 0; y < canvas.height; y += spacing) {
+      for (let x = 0; x < canvas.width; x += spacing) {
+        ctx.beginPath();
+        ctx.arc(x + spacing / 2, y + spacing / 2, 1.5, 0, Math.PI * 2);
+        ctx.fill();
+      }
     }
   }
 
@@ -257,10 +260,12 @@ function inicializarSimulacionAvanzada() {
   }
 
   [lpi, bcm, vel, cob].forEach(el => {
-    el.addEventListener('input', () => {
+    const handler = () => {
       if (DEBUG) console.log('[SIM] slider', el.id, el.value);
       renderSimulation();
-    });
+    };
+    el.addEventListener('input', handler);
+    el.addEventListener('change', handler);
   });
   if (DEBUG) console.debug('listeners attached');
   let resizeTimeout;


### PR DESCRIPTION
## Summary
- Reutiliza la imagen del diagnóstico con advertencias como base de la simulación avanzada.
- Añade patrón de puntos como fondo de respaldo cuando no hay imagen.
- Mejora los sliders para recalcular siempre la simulación.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6636f8c848322b36035e5466f44c5