### PR TITLE
Reintegrar imagen base y sliders en simulación flexo

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -1426,6 +1426,12 @@ def resultado_flexo():
             "warning",
         )
         return redirect(url_for("revision"))
+    # Asegurar que la simulación avanzada reciba la ruta de la imagen del
+    # diagnóstico.  Versiones anteriores podían no incluir ``diag_img_web`` en
+    # ``res.json``; en ese caso, reutilizamos la imagen con iconos si existe.
+    if "diag_img_web" not in datos:
+        datos["diag_img_web"] = datos.get("imagen_iconos_web") or datos.get("imagen_path_web")
+
     return render_template("resultado_flexo.html", **datos, revision_id=revision_id)
 
 

--- a/static/js/flexo_simulation.js
+++ b/static/js/flexo_simulation.js
@@ -68,30 +68,38 @@ function inicializarSimulacionAvanzada() {
 
   const img = new Image();
   img.crossOrigin = 'anonymous';
-  // Intentar reutilizar la imagen del diagnóstico con advertencias.  Si no se
-  // proporciona explícitamente, buscarla en uploads/<revision_id>.
-  const diagUrl =
-    window.diagImg ||
-    (window.revisionId
-      ? `/static/uploads/${window.revisionId}/diagnostico_iconos.png`
-      : null);
-  if (diagUrl) {
-    img.onload = () => {
+
+  // Carga la imagen base del diagnóstico, con un fallback si la ruta no
+  // está disponible.  Esto garantiza que el canvas nunca se dibuje vacío.
+  function cargarImagenBase() {
+    const diagUrl =
+      window.diagImg ||
+      (window.revisionId
+        ? `/static/uploads/${window.revisionId}/diagnostico_iconos.png`
+        : null);
+
+    if (!diagUrl) {
+      renderSimulation();
+      return;
+    }
+
+    const onReady = () => {
       if (DEBUG) console.log('[SIM] imagen base cargada');
       renderSimulation();
     };
+
+    img.onload = onReady;
     img.onerror = () => {
       if (DEBUG) console.warn('[SIM] error cargando imagen base');
       renderSimulation();
     };
     img.src = diagUrl;
-    if (img.complete && img.naturalWidth > 0) {
-      if (DEBUG) console.log('[SIM] imagen base ya disponible');
-      renderSimulation();
-    }
-  } else {
-    renderSimulation();
+
+    // Si la imagen ya está en caché, forzar el render inmediatamente.
+    if (img.complete && img.naturalWidth > 0) onReady();
   }
+
+  cargarImagenBase();
 
   function actualizarValores() {
     lpiVal.textContent = `${lpi.value} lpi`;

--- a/templates/resultado_flexo.html
+++ b/templates/resultado_flexo.html
@@ -366,7 +366,7 @@
   <script>
     window.diagnosticoFlexo = {{ diagnostico_json | default({}) | tojson }};
     window.revisionId = "{{ revision_id or '' }}";
-    window.diagImg = "{{ url_for('static', filename=diag_img_web) if diag_img_web else '' }}";
+    window.diagImg = "{{ url_for('static', filename=diag_img_web or imagen_iconos_web or imagen_path_web) if (diag_img_web or imagen_iconos_web or imagen_path_web) else '' }}";
   </script>
   <script src="{{ url_for('static', filename='js/flexo_simulation.js') }}?v=3" defer></script>
 </body>


### PR DESCRIPTION
## Summary
- Cargar automáticamente la imagen del diagnóstico en la simulación avanzada, con patrón de respaldo si falta
- Exponer en la plantilla el path del diagnóstico y forzar su inclusión desde las rutas
- Asegurar que resultados antiguos también provean `diag_img_web` para el canvas

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c6673be8cc832291a81d4f25ee8806