### PR TITLE
Refine flexo ink transmission simulation using material coefficients

### DIFF
--- a/data/material_coefficients.json
+++ b/data/material_coefficients.json
@@ -1,0 +1,6 @@
+{
+  "default": 0.8,
+  "film": 0.92,
+  "papel": 0.78,
+  "carton": 0.85
+}

--- a/templates/resultado_flexo.html
+++ b/templates/resultado_flexo.html
@@ -273,6 +273,13 @@
       font-size: 0.85rem;
       color: #1b3a57;
     }
+    .coverage-ink {
+      margin-top: 0.5rem;
+    }
+    .coverage-ink li {
+      font-size: 0.8rem;
+      color: #3d566e;
+    }
     .riesgo-detalle {
       list-style: disc;
       margin: 1rem 0;
@@ -489,6 +496,10 @@
       <div class="datos-col">
         <p><strong>Archivo PDF:</strong> {{ diag.get('archivo', 'diagnostico.pdf') }}</p>
         <p><strong>Material de impresión:</strong> {{ diag.get('material', '(calculado en diagnóstico)') }}</p>
+        {% set coef_material_val = material_coeficiente if material_coeficiente is defined and material_coeficiente is not none else diag.get('coef_material') %}
+        {% if coef_material_val is not none %}
+        <p><strong>Coeficiente de transmisión:</strong> {{ '%0.2f' % coef_material_val }}</p>
+        {% endif %}
         <p><strong>Anilox LPI (diagnóstico):</strong> {{ lpi_display }}{% if lpi_diag is none %} (estimado){% endif %}</p>
         <p><strong>BCM del anilox:</strong> {{ bcm_display }}{% if bcm_diag is none %} (estimado){% endif %}</p>
         <p><strong>Velocidad de cálculo:</strong> {{ vel_display }} m/min{% if vel_diag is none %} (estimada){% endif %}</p>
@@ -561,6 +572,8 @@
             <span class="titulo">Transmisión de tinta estimada</span>
             <span id="metric-ml" class="valor">--</span>
             <small id="metric-ml-detalle" class="detalle"></small>
+            <small class="detalle">Distribución por canal:</small>
+            <ul id="metric-ml-colors" class="coverage-list coverage-ink"></ul>
           </li>
           <li>
             <span class="titulo">TAC del archivo</span>
@@ -597,6 +610,7 @@
     <a href="{{ url_for('static', filename=imagen_iconos_web) }}" class="btn" download>⬇ Descargar imagen con advertencias</a>
     <a href="{{ url_for('revision') }}" class="btn">⬅ Volver a revisar otro diseño</a>
   </div>
+  {% set coef_material_context = material_coeficiente if material_coeficiente is defined and material_coeficiente is not none else diag.get('coef_material') %}
   <script>
     window.diag_img_web = {{ diag_img_static|tojson }};
     window.revisionId = {{ (revision_id or '')|tojson }};
@@ -604,6 +618,8 @@
     window.analisisDetallado = {{ (analisis or {})|tojson }};
     window.indicadoresAdvertencias = {{ (indicadores_advertencias or diag_stats or {})|tojson }};
     window.advertenciasResumen = {{ (advertencias_txt or '')|tojson }};
+    window.materialCoefficients = {{ (material_coefficients|default({}, true))|tojson }};
+    window.materialCoefSeleccionado = {{ coef_material_context|tojson }};
   </script>
   <script src="{{ url_for('static', filename='js/flexo_simulation.js') }}?v={{ revision_id }}" defer></script>
 </body>

--- a/tests/test_diagnostico_flexo.py
+++ b/tests/test_diagnostico_flexo.py
@@ -7,7 +7,12 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from cobertura_utils import calcular_metricas_cobertura
-from diagnostico_flexo import resumen_advertencias, semaforo_riesgo
+from diagnostico_flexo import (
+    resumen_advertencias,
+    semaforo_riesgo,
+    coeficiente_material,
+    obtener_coeficientes_material,
+)
 from montaje_flexo import detectar_tramas_débiles
 from simulador_riesgos import simular_riesgos
 
@@ -106,3 +111,24 @@ def test_simulador_riesgos_ignora_texto_negado():
     resumen = "✔️ No se encontraron textos menores a 4 pt."
     html = simular_riesgos(resumen)
     assert "Textos < 4 pt" not in html
+
+
+def test_coeficiente_material_usa_json():
+    """Los coeficientes de materiales se obtienen desde el JSON compartido."""
+
+    coefs = obtener_coeficientes_material()
+    assert coefs, "Se esperaba un mapa de coeficientes cargado desde data/material_coefficients.json"
+    film = coefs.get("film")
+    carton = coefs.get("carton")
+    default_val = coefs.get("default")
+
+    if film is not None:
+        assert coeficiente_material("Film") == film
+    if carton is not None:
+        assert coeficiente_material("cartón") == carton
+
+    if default_val is not None:
+        assert coeficiente_material("material desconocido") == default_val
+
+    override = coeficiente_material("material sin registrar", default=0.71)
+    assert override == 0.71

--- a/tests/test_resultado_flexo_template.py
+++ b/tests/test_resultado_flexo_template.py
@@ -23,3 +23,4 @@ def test_default_warning_message_in_template():
                 diag_img_web='dummy.png',
             )
     assert 'Advertencia sin descripción detallada.' in html
+    assert 'metric-ml-colors' in html


### PR DESCRIPTION
## Summary
- add shared JSON with ink transmission coefficients by material and expose helpers to read them in the flexo diagnostic
- persist material coefficients in the flexo routes so the result view and simulation can use real job data
- overhaul the advanced simulation to compute ink transmission per color with the new formula, update risk messages, and render UI for per-channel results
- surface the coefficient and per-color values in the flexo result template and extend automated tests for the new logic

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cce07274d483228b3154f720e9a557