### PR TITLE
Respect diagnosed width in efficiency calculation

### DIFF
--- a/static/js/flexo_simulation.js
+++ b/static/js/flexo_simulation.js
@@ -692,7 +692,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const vel = asNumber(velocidad);
     const anchoVal = asNumber(ancho);
     const velBase = vel !== null ? Math.max(vel, 30) : 150;
-    const anchoBase = anchoVal !== null ? Math.max(anchoVal, 0.2) : 0.35;
+    const anchoBase = anchoVal !== null && anchoVal > 0 ? anchoVal : 0.35;
     const velFactor = velBase / 150;
     const anchoFactor = anchoBase / 0.35;
     const eficiencia = velFactor * 0.7 + anchoFactor * 0.3;


### PR DESCRIPTION
## Summary
- remove the artificial 0.20 m floor so efficiency uses the diagnosed width
- fall back to 0.35 m only when the diagnosis does not provide a positive width

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf46f89414832297aadf39ace405da