### PR TITLE
CTP: liquidación con ítems y tabla puente documento-órdenes (sin cambios en core)

### DIFF
--- a/ctp-modulo/includes/db.php
+++ b/ctp-modulo/includes/db.php
@@ -10,6 +10,7 @@ function ctp_modulo_install(): void {
 
     $ordenes_table = $wpdb->prefix . 'ctp_ordenes';
     $items_table = $wpdb->prefix . 'ctp_orden_items';
+    $liquidacion_ordenes_table = $wpdb->prefix . 'ctp_liquidacion_ordenes';
 
     $sql_ordenes = "CREATE TABLE {$ordenes_table} (
         id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
@@ -42,10 +43,22 @@ function ctp_modulo_install(): void {
         KEY orden_id (orden_id)
     ) {$charset_collate};";
 
+    $sql_liquidacion_ordenes = "CREATE TABLE {$liquidacion_ordenes_table} (
+        id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+        documento_id BIGINT UNSIGNED NOT NULL,
+        orden_id BIGINT UNSIGNED NOT NULL,
+        created_at DATETIME NOT NULL,
+        PRIMARY KEY (id),
+        UNIQUE KEY documento_orden (documento_id, orden_id),
+        KEY documento_id (documento_id),
+        KEY orden_id (orden_id)
+    ) {$charset_collate};";
+
     require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 
     dbDelta($sql_ordenes);
     dbDelta($sql_items);
+    dbDelta($sql_liquidacion_ordenes);
 
     ctp_modulo_maybe_add_column($ordenes_table, 'documento_id', 'BIGINT UNSIGNED NULL');
     ctp_modulo_maybe_add_column($ordenes_table, 'estado', "ENUM('pendiente','liquidada','anulada') NOT NULL DEFAULT 'pendiente'");
@@ -57,11 +70,13 @@ function ctp_modulo_tables_exist(): bool {
     global $wpdb;
     $ordenes_table = $wpdb->prefix . 'ctp_ordenes';
     $items_table = $wpdb->prefix . 'ctp_orden_items';
+    $liquidacion_ordenes_table = $wpdb->prefix . 'ctp_liquidacion_ordenes';
 
     $ordenes_exists = $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $ordenes_table));
     $items_exists = $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $items_table));
+    $liquidacion_ordenes_exists = $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $liquidacion_ordenes_table));
 
-    return !empty($ordenes_exists) && !empty($items_exists);
+    return !empty($ordenes_exists) && !empty($items_exists) && !empty($liquidacion_ordenes_exists);
 }
 
 function ctp_modulo_maybe_add_column(string $table, string $column, string $definition): void {

--- a/ctp-modulo/includes/handlers-liquidaciones.php
+++ b/ctp-modulo/includes/handlers-liquidaciones.php
@@ -16,9 +16,15 @@ function ctp_handle_generar_liquidacion(): void {
 
     global $wpdb;
     $ordenes_table = ctp_get_table('ctp_ordenes');
+    $liquidacion_ordenes_table = ctp_get_table('ctp_liquidacion_ordenes');
 
     $cliente_id = absint($_POST['cliente_id'] ?? 0);
-    $ordenes_ids = isset($_POST['orden_ids']) ? array_map('absint', (array) wp_unslash($_POST['orden_ids'])) : array();
+    $ordenes_ids = isset($_POST['orden_ids']) ? array_unique(array_filter(array_map('absint', (array) wp_unslash($_POST['orden_ids'])))) : array();
+    $detalle_items = isset($_POST['detalle_items']) ? sanitize_key(wp_unslash($_POST['detalle_items'])) : 'orden';
+
+    if (!in_array($detalle_items, array('orden', 'item'), true)) {
+        $detalle_items = 'orden';
+    }
 
     if (!$cliente_id || !$ordenes_ids) {
         ctp_redirect_with_notice('Selecciona un cliente y al menos una orden.', 'error');
@@ -42,15 +48,68 @@ function ctp_handle_generar_liquidacion(): void {
         ctp_redirect_with_notice('No hay órdenes pendientes válidas para liquidar.', 'error');
     }
 
-    $total = 0;
+    if (count($ordenes) !== count($ordenes_ids)) {
+        ctp_redirect_with_notice('Alguna orden seleccionada no es válida para liquidar.', 'error');
+    }
+
+    $total = 0.0;
     $nros = array();
+    $document_items = array();
+
     foreach ($ordenes as $orden) {
-        $total += (float) $orden['total_orden'];
+        $orden_total = (float) $orden['total_orden'];
+        $total += $orden_total;
         $nros[] = $orden['nro_orden'];
+
+        if ($detalle_items === 'item') {
+            $orden_items = ctp_get_order_items((int) $orden['id']);
+            if (!$orden_items) {
+                ctp_redirect_with_notice('No se encontraron ítems en una de las órdenes seleccionadas.', 'error');
+            }
+
+            foreach ($orden_items as $item) {
+                $item_total = isset($item['total']) ? (float) $item['total'] : 0.0;
+                $item_cantidad = isset($item['cantidad']) ? (float) $item['cantidad'] : 0.0;
+                $item_precio_unit = isset($item['precio_unit']) ? (float) $item['precio_unit'] : 0.0;
+
+                if ($item_total <= 0 || $item_cantidad <= 0) {
+                    ctp_redirect_with_notice('Hay ítems inválidos (cantidad/total) en las órdenes seleccionadas.', 'error');
+                }
+
+                $document_items[] = array(
+                    'descripcion' => sprintf('CTP Orden #%s - %s', $orden['nro_orden'], (string) $item['medida']),
+                    'cantidad' => $item_cantidad,
+                    'precio_unit' => $item_precio_unit,
+                    'total' => $item_total,
+                );
+            }
+
+            continue;
+        }
+
+        if ($orden_total <= 0) {
+            ctp_redirect_with_notice('Hay órdenes con total inválido para liquidar.', 'error');
+        }
+
+        $document_items[] = array(
+            'descripcion' => sprintf('CTP Orden #%s - %s', $orden['nro_orden'], $orden['nombre_trabajo']),
+            'cantidad' => 1,
+            'precio_unit' => $orden_total,
+            'total' => $orden_total,
+        );
     }
 
     if ($total <= 0) {
         ctp_redirect_with_notice('El total de la liquidación debe ser mayor a cero.', 'error');
+    }
+
+    $sum_items = 0.0;
+    foreach ($document_items as $doc_item) {
+        $sum_items += (float) $doc_item['total'];
+    }
+
+    if (abs($sum_items - $total) > 0.01) {
+        ctp_redirect_with_notice('La suma de ítems no coincide con el total de la liquidación.', 'error');
     }
 
     $prefix = 'LIQ-CTP-' . gmdate('Ym') . '-' . $cliente_id . '-';
@@ -72,8 +131,18 @@ function ctp_handle_generar_liquidacion(): void {
         ctp_redirect_with_notice($documento_id->get_error_message(), 'error');
     }
 
+    $wpdb->query('START TRANSACTION');
+
+    foreach ($document_items as $doc_item) {
+        $item_result = gc_api_add_documento_item((int) $documento_id, $doc_item);
+        if (is_wp_error($item_result)) {
+            $wpdb->query('ROLLBACK');
+            ctp_redirect_with_notice($item_result->get_error_message(), 'error');
+        }
+    }
+
     foreach ($ordenes as $orden) {
-        $wpdb->update(
+        $updated = $wpdb->update(
             $ordenes_table,
             array(
                 'estado' => 'liquidada',
@@ -84,10 +153,31 @@ function ctp_handle_generar_liquidacion(): void {
             array('%s', '%d', '%s'),
             array('%d')
         );
+
+        if ($updated === false) {
+            $wpdb->query('ROLLBACK');
+            ctp_redirect_with_notice('No se pudo actualizar el estado de una orden. No se aplicaron cambios.', 'error');
+        }
+
+        $inserted_relation = $wpdb->insert(
+            $liquidacion_ordenes_table,
+            array(
+                'documento_id' => (int) $documento_id,
+                'orden_id' => (int) $orden['id'],
+                'created_at' => gc_now(),
+            ),
+            array('%d', '%d', '%s')
+        );
+
+        if (!$inserted_relation) {
+            $wpdb->query('ROLLBACK');
+            ctp_redirect_with_notice('No se pudo registrar la relación documento-orden. No se aplicaron cambios.', 'error');
+        }
     }
 
-    $ref_id = isset($ordenes[0]['id']) ? (int) $ordenes[0]['id'] : 0;
-    gc_api_link_external_ref((int) $documento_id, 'ctp_liquidacion', $ref_id);
+    $wpdb->query('COMMIT');
+
+    gc_api_link_external_ref((int) $documento_id, 'ctp_liquidacion', (int) $documento_id);
 
     ctp_redirect_with_notice('Liquidación generada correctamente.', 'success');
 }

--- a/ctp-modulo/includes/shortcodes-liquidaciones.php
+++ b/ctp-modulo/includes/shortcodes-liquidaciones.php
@@ -66,6 +66,10 @@ function ctp_render_liquidaciones_shortcode(): string {
     $table_html .= wp_nonce_field('ctp_generar_liquidacion', '_wpnonce', true, false);
     $table_html .= '<input type="hidden" name="action" value="ctp_generar_liquidacion">';
     $table_html .= '<input type="hidden" name="cliente_id" value="' . esc_attr($cliente_id) . '">';
+    $table_html .= '<fieldset class="ctp-detalle-items"><legend>Detalle de ítems</legend>'
+        . '<label><input type="radio" name="detalle_items" value="orden" checked> Por orden</label>'
+        . '<label><input type="radio" name="detalle_items" value="item"> Por ítem</label>'
+        . '</fieldset>';
     $table_html .= '<div class="gc-table-wrap"><table class="gc-table">'
         . '<thead><tr><th></th><th>Fecha</th><th>N° Orden</th><th>Trabajo</th><th>Total</th></tr></thead>'
         . '<tbody>' . $rows_html . '</tbody></table></div>';


### PR DESCRIPTION
### Motivation
- Añadir soporte para crear documentos de venta con ítems desde el módulo CTP y mantener una relación 1 documento -> N órdenes dentro de CTP sin tocar el core.
- Permitir dos niveles de detalle en la liquidación (`orden` por defecto o `item`) para generar ítems en el documento según la selección.
- Evitar documentos huérfanos validando todo antes de crear el documento y aplicando transacción en las modificaciones internas del módulo.

### Description
- Se creó la tabla puente `{$wpdb->prefix}ctp_liquidacion_ordenes` en `ctp_modulo_install()` y se añadió su verificación en `ctp_modulo_tables_exist()` para instalación/auto-reparación (`ctp-modulo/includes/db.php`).
- Se extendió `ctp_handle_generar_liquidacion()` para soportar el parámetro POST `detalle_items` con valores `orden` (default) y `item`, construir la lista de ítems correspondientes y añadirlos al documento usando la API del core (`gc_api_add_documento_item`), además de enlazar vía `gc_api_link_external_ref` (`ctp-modulo/includes/handlers-liquidaciones.php`).
- Se agregó transacción MySQL en el módulo CTP: `START TRANSACTION` antes de aplicar cambios locales, rollbacks en caso de error al agregar ítems, actualizar órdenes o insertar la relación puente, y `COMMIT` al final; las validaciones (órdenes válidas/pendientes, total > 0, existencia/validez de ítems y suma consistente ±0.01) se realizan antes de crear el documento para evitar huérfanos.
- Se añadió control UI al shortcode: radio `name="detalle_items"` con opciones `orden`/`item` y envío por POST al handler para elegir el modo de detalle (`ctp-modulo/includes/shortcodes-liquidaciones.php`).
- Se respetaron las restricciones: no se modificó `gestion-core-global/*`, se usaron únicamente las funciones públicas del core mencionadas y se mantuvieron `gc_guard_manage_access()` y `check_admin_referer('ctp_generar_liquidacion')`.

### Testing
- Se verificó sintaxis PHP con `php -l` en los archivos modificados: `ctp-modulo/includes/db.php`, `ctp-modulo/includes/handlers-liquidaciones.php` y `ctp-modulo/includes/shortcodes-liquidaciones.php`, todos sin errores.
- Se generó un snapshot UI del formulario de Liquidaciones mediante un script headless (Playwright) para validar la presencia del selector de detalle y el formulario, y el script ejecutó correctamente produciendo la imagen de referencia.
- Se revisaron los diffs y la integración local para asegurar que solo se tocaron los archivos del módulo CTP y que las llamadas a la API del core se mantienen sin cambios.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a125a0a4088322a9348c30bd9d3665)